### PR TITLE
use git instead of path to git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/solana"]
-	path = deps/solana
-	url = https://github.com/blockworks-foundation/solana.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,6 +3807,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -3829,6 +3830,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3848,6 +3850,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bv",
  "fnv",
@@ -3865,6 +3868,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3882,6 +3886,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "log",
  "memmap2",
@@ -3895,6 +3900,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -3911,6 +3917,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3925,6 +3932,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "log",
  "solana-measure",
@@ -3940,6 +3948,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk 1.15.0",
@@ -3948,6 +3957,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "chrono",
@@ -3960,6 +3970,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -3981,6 +3992,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4037,6 +4049,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "ahash",
  "blake3",
@@ -4081,6 +4094,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -4091,6 +4105,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "bv",
@@ -4135,6 +4150,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -4204,6 +4220,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4213,6 +4230,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "log",
  "solana-sdk 1.15.0",
@@ -4221,6 +4239,7 @@ dependencies = [
 [[package]]
 name = "solana-merkle-tree"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "fast-math",
  "matches",
@@ -4230,6 +4249,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4242,6 +4262,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -4262,6 +4283,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "ahash",
  "bincode",
@@ -4287,6 +4309,7 @@ dependencies = [
 [[package]]
 name = "solana-poh"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -4353,6 +4376,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4400,6 +4424,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4425,6 +4450,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4448,6 +4474,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4456,6 +4483,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "console",
  "dialoguer",
@@ -4473,6 +4501,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4525,6 +4554,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4549,6 +4579,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "base64 0.13.1",
  "bs58",
@@ -4569,6 +4600,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -4580,6 +4612,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "arrayref",
  "bincode",
@@ -4692,6 +4725,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -4755,6 +4789,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.47",
@@ -4766,6 +4801,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -4779,6 +4815,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "log",
@@ -4792,6 +4829,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "backoff",
  "bincode",
@@ -4824,6 +4862,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "bs58",
@@ -4839,6 +4878,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4868,6 +4908,7 @@ dependencies = [
 [[package]]
 name = "solana-sys-tuner"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "clap 2.34.0",
  "libc",
@@ -4883,6 +4924,7 @@ dependencies = [
 [[package]]
 name = "solana-thin-client"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "log",
@@ -4895,6 +4937,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4928,6 +4971,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -4952,6 +4996,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "log",
  "rustc_version",
@@ -4966,6 +5011,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bincode",
  "log",
@@ -4986,6 +5032,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -5030,6 +5077,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "1.15.0"
+source = "git+https://github.com/blockworks-foundation/solana.git#ed2f4b21577719b3068ab315c2f4504007225bf0"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,33 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-solana-client={path = "deps/solana/client"}
-solana-sdk={path = "deps/solana/sdk"}
+solana-client = { git = "https://github.com/blockworks-foundation/solana.git" }
+solana-sdk = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-clap-utils = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-cli-config = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-pubsub-client = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-account-decoder = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-entry = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-faucet = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-gossip = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-ledger = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-measure = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-metrics = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-perf = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-poh = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-rayon-threadlimit = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-rpc-client-api = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-runtime = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-send-transaction-service = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-stake-program = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-storage-bigtable = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-streamer = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-tpu-client = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-transaction-status = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-version = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-vote-program = { git = "https://github.com/blockworks-foundation/solana.git" } 
+solana-rpc = { git = "https://github.com/blockworks-foundation/solana.git" } 
+
 tokio = { version = "1.14.1", features = ["full"]}
 futures = "0.3.25"
 jsonrpc-core = "18.0.0"
@@ -15,11 +40,7 @@ jsonrpc-core-client = { version = "18.0.0" }
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
-solana-rpc = {path = "deps/solana/rpc"}
 clap = "2.33.1"
-solana-clap-utils = { path = "deps/solana/clap-utils" }
-solana-cli-config = { path = "deps/solana/cli-config" }
-solana-pubsub-client = { path = "deps/solana/pubsub-client" }
 
 base64 = "0.13.0"
 bincode = "1.3.3"
@@ -35,26 +56,6 @@ serde = "1.0.144"
 serde_derive = "1.0.103"
 serde_json = "1.0.83"
 soketto = "0.7"
-solana-account-decoder = { path = "deps/solana/account-decoder", version = "=1.15.0" }
-solana-entry = { path = "deps/solana/entry", version = "=1.15.0" }
-solana-faucet = { path = "deps/solana/faucet", version = "=1.15.0" }
-solana-gossip = { path = "deps/solana/gossip", version = "=1.15.0" }
-solana-ledger = { path = "deps/solana/ledger", version = "=1.15.0" }
-solana-measure = { path = "deps/solana/measure", version = "=1.15.0" }
-solana-metrics = { path = "deps/solana/metrics", version = "=1.15.0" }
-solana-perf = { path = "deps/solana/perf", version = "=1.15.0" }
-solana-poh = { path = "deps/solana/poh", version = "=1.15.0" }
-solana-rayon-threadlimit = { path = "deps/solana/rayon-threadlimit", version = "=1.15.0" }
-solana-rpc-client-api = { path = "deps/solana/rpc-client-api", version = "=1.15.0" }
-solana-runtime = { path = "deps/solana/runtime", version = "=1.15.0" }
-solana-send-transaction-service = { path = "deps/solana/send-transaction-service", version = "=1.15.0" }
-solana-stake-program = { path = "deps/solana/programs/stake", version = "=1.15.0" }
-solana-storage-bigtable = { path = "deps/solana/storage-bigtable", version = "=1.15.0" }
-solana-streamer = { path = "deps/solana/streamer", version = "=1.15.0" }
-solana-tpu-client = { path = "deps/solana/tpu-client", version = "=1.15.0", default-features = false }
-solana-transaction-status = { path = "deps/solana/transaction-status", version = "=1.15.0" }
-solana-version = { path = "deps/solana/version", version = "=1.15.0" }
-solana-vote-program = { path = "deps/solana/programs/vote", version = "=1.15.0" }
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "=0.4.3", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"


### PR DESCRIPTION
Use a `git` for dependency resolution instead of file path.
Prevents `git submodule`.
