### PR TITLE
Implementation of getBlocks and implementation of various block storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4410,6 +4410,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-lite-rpc-storage"
+version = "0.2.2"
+dependencies = [
+ "async-trait",
+ "dashmap",
+ "solana-lite-rpc-core",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
+ "solana-transaction-status",
+ "tokio",
+]
+
+[[package]]
 name = "solana-logger"
 version = "1.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ dotenv = "0.15.0"
 async-channel = "1.8.0"
 quinn = "0.9.3"
 rustls = { version = "=0.20.8", default-features = false }
-<<<<<<< HEAD
 solana-lite-rpc-services = {path = "services", version="0.2.3"}
 solana-lite-rpc-core = {path = "core", version="0.2.3"}
 solana-lite-rpc-cluster-endpoints = {path = "cluster-endpoints", version="0.2.3"}
@@ -61,10 +60,3 @@ solana-lite-rpc-cluster-endpoints = {path = "cluster-endpoints", version="0.2.3"
 async-trait = "0.1.68"
 yellowstone-grpc-client = "1.9.0"
 yellowstone-grpc-proto = "1.9.0"
-=======
-async-trait = "0.1.68"
-
-solana-lite-rpc-services = {path = "services", version="0.2.2"}
-solana-lite-rpc-core = {path = "core", version="0.2.2"}
-solana-lite-rpc-storage = {path = "storage", version="0.2.2"}
->>>>>>> 6e7c29c (Implementing getBlock, and implementing multiple block storage. Inmemory for non finalized blocks, a generic implementation for other block, faithful for legacy blocks)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "core",
     "services",
     "lite-rpc",
+    "storage",
     "quic-forward-proxy",
     "quic-forward-proxy-integration-test",
     "cluster-endpoints",
@@ -52,6 +53,7 @@ dotenv = "0.15.0"
 async-channel = "1.8.0"
 quinn = "0.9.3"
 rustls = { version = "=0.20.8", default-features = false }
+<<<<<<< HEAD
 solana-lite-rpc-services = {path = "services", version="0.2.3"}
 solana-lite-rpc-core = {path = "core", version="0.2.3"}
 solana-lite-rpc-cluster-endpoints = {path = "cluster-endpoints", version="0.2.3"}
@@ -59,3 +61,10 @@ solana-lite-rpc-cluster-endpoints = {path = "cluster-endpoints", version="0.2.3"
 async-trait = "0.1.68"
 yellowstone-grpc-client = "1.9.0"
 yellowstone-grpc-proto = "1.9.0"
+=======
+async-trait = "0.1.68"
+
+solana-lite-rpc-services = {path = "services", version="0.2.2"}
+solana-lite-rpc-core = {path = "core", version="0.2.2"}
+solana-lite-rpc-storage = {path = "storage", version="0.2.2"}
+>>>>>>> 6e7c29c (Implementing getBlock, and implementing multiple block storage. Inmemory for non finalized blocks, a generic implementation for other block, faithful for legacy blocks)

--- a/core/src/block_storage_interface.rs
+++ b/core/src/block_storage_interface.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+use solana_sdk::{commitment_config::CommitmentLevel, slot_history::Slot};
+use solana_transaction_status::UiConfirmedBlock;
+use std::sync::Arc;
+
+#[async_trait]
+pub trait BlockStorageInterface: Send + Sync {
+    async fn save(&self, slot: Slot, block: UiConfirmedBlock, commitment: CommitmentLevel);
+    async fn get(&self, slot: Slot) -> Option<UiConfirmedBlock>;
+}
+
+pub type BlockStorageImpl = Arc<dyn BlockStorageInterface>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cluster_info;
 pub mod data_cache;
 pub mod keypair_loader;
 pub mod leaders_fetcher_trait;
+pub mod block_storage_interface;
 pub mod notifications;
 pub mod proxy_request_format;
 pub mod quic_connection;

--- a/lite-rpc/src/bridge.rs
+++ b/lite-rpc/src/bridge.rs
@@ -17,7 +17,10 @@ use solana_lite_rpc_core::{
 };
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::{
-    config::{RpcContextConfig, RpcRequestAirdropConfig, RpcSignatureStatusConfig},
+    config::{
+        RpcBlockConfig, RpcContextConfig, RpcEncodingConfigWrapper, RpcRequestAirdropConfig,
+        RpcSignatureStatusConfig,
+    },
     response::{Response as RpcResponse, RpcBlockhash, RpcResponseContext, RpcVersionInfo},
 };
 use solana_sdk::{
@@ -332,5 +335,19 @@ impl LiteRpcServer for LiteBridge {
         );
 
         Ok(())
+    }
+
+    async fn get_block(
+        &self,
+        slot: u64,
+        _config: Option<RpcEncodingConfigWrapper<RpcBlockConfig>>,
+    ) -> crate::rpc::Result<Option<UiConfirmedBlock>> {
+        if let Some(block_storage) = &self.block_storage {
+            Ok(block_storage.get(slot).await)
+        } else {
+            Err(jsonrpsee::core::Error::Custom(
+                "Does not support get_block".to_string(),
+            ))
+        }
     }
 }

--- a/lite-rpc/src/cli.rs
+++ b/lite-rpc/src/cli.rs
@@ -11,6 +11,8 @@ pub struct Args {
     pub rpc_addr: String,
     #[arg(short, long, default_value_t = String::from(DEFAULT_WS_ADDR))]
     pub ws_addr: String,
+    #[arg(short = 't', long, default_value_t = String::new())]
+    pub faithful_service_address: String,
     #[arg(short = 'l', long, default_value_t = String::from("[::]:8890"))]
     pub lite_rpc_http_addr: String,
     #[arg(short = 's', long, default_value_t = String::from("[::]:8891"))]

--- a/lite-rpc/src/rpc.rs
+++ b/lite-rpc/src/rpc.rs
@@ -1,12 +1,13 @@
 use jsonrpsee::core::SubscriptionResult;
 use jsonrpsee::proc_macros::rpc;
 use solana_rpc_client_api::config::{
-    RpcContextConfig, RpcRequestAirdropConfig, RpcSignatureStatusConfig,
+    RpcBlockConfig, RpcContextConfig, RpcEncodingConfigWrapper, RpcRequestAirdropConfig,
+    RpcSignatureStatusConfig,
 };
 use solana_rpc_client_api::response::{Response as RpcResponse, RpcBlockhash, RpcVersionInfo};
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::slot_history::Slot;
-use solana_transaction_status::TransactionStatus;
+use solana_transaction_status::{TransactionStatus, UiConfirmedBlock};
 
 use crate::configs::{IsBlockHashValidConfig, SendTransactionConfig};
 
@@ -54,6 +55,13 @@ pub trait LiteRpc {
 
     #[method(name = "getSlot")]
     async fn get_slot(&self, config: Option<RpcContextConfig>) -> Result<Slot>;
+
+    #[method(name = "getBlock")]
+    async fn get_block(
+        &self,
+        slot: u64,
+        config: Option<RpcEncodingConfigWrapper<RpcBlockConfig>>,
+    ) -> Result<Option<UiConfirmedBlock>>;
 
     #[subscription(name = "signatureSubscribe" => "signatureNotification", unsubscribe="signatureUnsubscribe", item=RpcResponse<serde_json::Value>)]
     async fn signature_subscribe(

--- a/services/src/transaction_service.rs
+++ b/services/src/transaction_service.rs
@@ -47,7 +47,7 @@ impl TransactionServiceBuilder {
     pub fn start(
         self,
         notifier: Option<NotificationSender>,
-        block_store: BlockInformationStore,
+        block_information_store: BlockInformationStore,
         max_retries: usize,
         slot_notifications: SlotStream,
     ) -> (TransactionService, AnyhowJoinHandle) {
@@ -86,7 +86,7 @@ impl TransactionServiceBuilder {
             TransactionService {
                 transaction_channel,
                 replay_channel,
-                block_store,
+                block_information_store,
                 max_retries,
                 replay_after: self.tx_replayer.retry_after,
             },
@@ -99,7 +99,7 @@ impl TransactionServiceBuilder {
 pub struct TransactionService {
     pub transaction_channel: Sender<TransactionInfo>,
     pub replay_channel: UnboundedSender<TransactionReplay>,
-    pub block_store: BlockInformationStore,
+    pub block_information_store: BlockInformationStore,
     pub max_retries: usize,
     pub replay_after: Duration,
 }
@@ -118,12 +118,8 @@ impl TransactionService {
         };
         let signature = tx.signatures[0];
 
-        let Some(BlockInformation {
-            slot,
-            last_valid_blockheight,
-            ..
-        }) = self
-            .block_store
+        let Some(BlockInformation { slot, last_valid_blockheight, .. }) = self
+            .block_information_store
             .get_block_info(&tx.get_recent_blockhash().to_string())
         else {
             bail!("Blockhash not found in block store".to_string());

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-lite-rpc-storage"
+version = "0.2.2"
+edition = "2021"
+description = "Storage implementations used by solana lite rpc"
+rust-version = "1.67.1"
+repository = "https://github.com/blockworks-foundation/lite-rpc"
+license = "AGPL"
+
+[dependencies]
+solana-sdk = { workspace = true }
+solana-transaction-status = { workspace = true }
+solana-rpc-client = { workspace = true }
+
+dashmap = {workspace = true}
+async-trait = { workspace = true }
+tokio = "1.*"
+
+solana-lite-rpc-core = {workspace = true}
+solana-rpc-client-api = {workspace = true}

--- a/storage/src/block_stores/inmemory_block_store.rs
+++ b/storage/src/block_stores/inmemory_block_store.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+use solana_lite_rpc_core::block_storage_interface::BlockStorageInterface;
+use solana_sdk::slot_history::Slot;
+use solana_transaction_status::UiConfirmedBlock;
+use std::collections::BTreeMap;
+use tokio::sync::RwLock;
+
+pub struct InmemoryBlockStore {
+    block_storage: RwLock<BTreeMap<Slot, UiConfirmedBlock>>,
+    number_of_blocks_to_store: usize,
+}
+
+impl InmemoryBlockStore {
+    pub fn new(number_of_blocks_to_store: usize) -> Self {
+        Self {
+            number_of_blocks_to_store,
+            block_storage: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    pub async fn store(&self, slot: Slot, block: UiConfirmedBlock) -> Option<UiConfirmedBlock> {
+        let mut block_storage = self.block_storage.write().await;
+        let min_slot = match block_storage.first_key_value() {
+            Some((slot, _)) => *slot,
+            None => 0,
+        };
+        if slot > min_slot {
+            block_storage.insert(slot, block);
+            if block_storage.len() > self.number_of_blocks_to_store {
+                block_storage.remove(&min_slot)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl BlockStorageInterface for InmemoryBlockStore {
+    async fn save(
+        &self,
+        slot: Slot,
+        block: UiConfirmedBlock,
+        _commitment: solana_sdk::commitment_config::CommitmentLevel,
+    ) {
+        self.store(slot, block).await;
+    }
+
+    async fn get(&self, slot: Slot) -> Option<UiConfirmedBlock> {
+        self.block_storage.read().await.get(&slot).cloned()
+    }
+}

--- a/storage/src/block_stores/mod.rs
+++ b/storage/src/block_stores/mod.rs
@@ -1,0 +1,1 @@
+pub mod inmemory_block_store;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod block_stores;
+pub mod multiple_strategy_block_store;

--- a/storage/src/multiple_strategy_block_store.rs
+++ b/storage/src/multiple_strategy_block_store.rs
@@ -1,0 +1,123 @@
+// A mixed block store,
+// Stores confirmed blocks in memory
+// Finalized blocks in long term storage of your choice
+// Fetches legacy blocks from faithful
+
+use crate::block_stores::inmemory_block_store::InmemoryBlockStore;
+use async_trait::async_trait;
+use solana_lite_rpc_core::block_storage_interface::{BlockStorageImpl, BlockStorageInterface};
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::config::RpcBlockConfig;
+use solana_sdk::{
+    commitment_config::{CommitmentConfig, CommitmentLevel},
+    slot_history::Slot,
+};
+use solana_transaction_status::{TransactionDetails, UiConfirmedBlock, UiTransactionEncoding};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+pub struct MultipleStrategyBlockStorage {
+    inmemory_for_storage: InmemoryBlockStore, // for confirmed blocks
+    persistent_block_storage: BlockStorageImpl, // for persistent block storage
+    faithful_rpc_client: Arc<RpcClient>,      // to fetch legacy blocks from faithful
+    number_of_slots_in_memory: usize,
+    last_confirmed_slot: Arc<AtomicU64>,
+}
+
+impl MultipleStrategyBlockStorage {
+    pub fn new(
+        persistent_block_storage: BlockStorageImpl,
+        faithful_url: String,
+        number_of_slots_in_memory: usize,
+    ) -> Self {
+        Self {
+            inmemory_for_storage: InmemoryBlockStore::new(number_of_slots_in_memory),
+            persistent_block_storage,
+            faithful_rpc_client: Arc::new(RpcClient::new(faithful_url)),
+            number_of_slots_in_memory,
+            last_confirmed_slot: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub async fn get_in_memory_block(&self, slot: Slot) -> Option<UiConfirmedBlock> {
+        self.inmemory_for_storage.get(slot).await
+    }
+}
+
+#[async_trait]
+impl BlockStorageInterface for MultipleStrategyBlockStorage {
+    async fn save(
+        &self,
+        slot: solana_sdk::slot_history::Slot,
+        block: solana_transaction_status::UiConfirmedBlock,
+        commitment: solana_sdk::commitment_config::CommitmentLevel,
+    ) {
+        if commitment == CommitmentLevel::Confirmed {
+            self.inmemory_for_storage
+                .save(slot, block, commitment)
+                .await;
+        } else if commitment == CommitmentLevel::Finalized {
+            let block_in_mem = self.inmemory_for_storage.get(slot).await;
+            if block_in_mem.is_none() {
+                self.inmemory_for_storage
+                    .save(slot, block.clone(), commitment)
+                    .await;
+            } else if let Some(block_in_mem) = block_in_mem {
+                // check if inmemory blockhash is same as finalized, update it if they are not
+                // we can have two machines with same identity publishing two different blocks on same slot
+                if block_in_mem.blockhash != block.blockhash {
+                    self.inmemory_for_storage
+                        .save(slot, block.clone(), commitment)
+                        .await;
+                }
+            }
+            self.persistent_block_storage
+                .save(slot, block, commitment)
+                .await;
+        }
+        if slot > self.last_confirmed_slot.load(Ordering::Relaxed) {
+            self.last_confirmed_slot.store(slot, Ordering::Relaxed);
+        }
+    }
+
+    async fn get(
+        &self,
+        slot: solana_sdk::slot_history::Slot,
+    ) -> Option<solana_transaction_status::UiConfirmedBlock> {
+        let last_confirmed_slot = self.last_confirmed_slot.load(Ordering::Relaxed);
+        if slot > last_confirmed_slot {
+            None
+        } else {
+            let diff = last_confirmed_slot.saturating_sub(slot);
+            if diff < self.number_of_slots_in_memory as u64 {
+                let block = self.inmemory_for_storage.get(slot).await;
+                if block.is_some() {
+                    return block;
+                }
+            }
+            // TODO: Define what data is expected that is definetly not in persistant block storage like data after epoch - 1
+            // check persistant block
+            let persistant_block = self.persistent_block_storage.get(slot).await;
+            if persistant_block.is_some() {
+                persistant_block
+            } else {
+                // fetch from faithful
+                self.faithful_rpc_client
+                    .get_block_with_config(
+                        slot,
+                        RpcBlockConfig {
+                            transaction_details: Some(TransactionDetails::Full),
+                            commitment: Some(CommitmentConfig::finalized()),
+                            max_supported_transaction_version: Some(0),
+                            encoding: Some(UiTransactionEncoding::Base64),
+                            rewards: Some(true),
+                        },
+                    )
+                    .await
+                    .ok()
+            }
+        }
+    }
+}

--- a/storage/tests/inmemory_block_store_tests.rs
+++ b/storage/tests/inmemory_block_store_tests.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use solana_lite_rpc_core::block_storage_interface::BlockStorageInterface;
+use solana_lite_rpc_storage::block_stores::inmemory_block_store::InmemoryBlockStore;
+use solana_sdk::{commitment_config::CommitmentLevel, hash::Hash};
+use solana_transaction_status::UiConfirmedBlock;
+
+pub fn create_test_ui_confirmed_block(slot: u64) -> UiConfirmedBlock {
+    UiConfirmedBlock {
+        block_height: Some(slot),
+        block_time: None,
+        blockhash: Hash::new_unique().to_string(),
+        parent_slot: slot - 1,
+        previous_blockhash: Hash::new_unique().to_string(),
+        rewards: None,
+        signatures: None,
+        transactions: Some(vec![]),
+    }
+}
+
+#[tokio::test]
+async fn inmemory_block_store_tests() {
+    // will store only 10 blocks
+    let store: Arc<dyn BlockStorageInterface> = Arc::new(InmemoryBlockStore::new(10));
+
+    // add 10 blocks
+    for i in 1..11 {
+        store
+            .save(
+                i,
+                create_test_ui_confirmed_block(i),
+                CommitmentLevel::Finalized,
+            )
+            .await;
+    }
+
+    // check if 10 blocks are added
+    for i in 1..11 {
+        assert!(store.get(i).await.is_some());
+    }
+    // add 11th block
+    store
+        .save(
+            11,
+            create_test_ui_confirmed_block(11),
+            CommitmentLevel::Finalized,
+        )
+        .await;
+
+    // can get 11th block
+    assert!(store.get(11).await.is_some());
+    // first block is removed
+    assert!(store.get(1).await.is_none());
+
+    // cannot add old blocks
+    store
+        .save(
+            1,
+            create_test_ui_confirmed_block(1),
+            CommitmentLevel::Finalized,
+        )
+        .await;
+    assert!(store.get(1).await.is_none());
+}

--- a/storage/tests/mod.rs
+++ b/storage/tests/mod.rs
@@ -1,0 +1,2 @@
+mod inmemory_block_store_tests;
+mod multiple_strategy_block_store_tests;

--- a/storage/tests/multiple_strategy_block_store_tests.rs
+++ b/storage/tests/multiple_strategy_block_store_tests.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+
+use solana_lite_rpc_core::block_storage_interface::BlockStorageInterface;
+use solana_lite_rpc_storage::{
+    block_stores::inmemory_block_store::InmemoryBlockStore,
+    multiple_strategy_block_store::MultipleStrategyBlockStorage,
+};
+use solana_sdk::hash::Hash;
+use solana_transaction_status::UiConfirmedBlock;
+
+pub fn create_test_ui_confirmed_block(slot: u64) -> UiConfirmedBlock {
+    UiConfirmedBlock {
+        block_height: Some(slot),
+        block_time: None,
+        blockhash: Hash::new_unique().to_string(),
+        parent_slot: slot - 1,
+        previous_blockhash: Hash::new_unique().to_string(),
+        rewards: None,
+        signatures: None,
+        transactions: Some(vec![]),
+    }
+}
+
+#[tokio::test]
+async fn test_in_multiple_stategy_block_store() {
+    let persistent_store: Arc<dyn BlockStorageInterface> = Arc::new(InmemoryBlockStore::new(10));
+    let number_of_slots_in_memory = 2;
+    let block_storage = MultipleStrategyBlockStorage::new(
+        persistent_store.clone(),
+        "".to_string(),
+        number_of_slots_in_memory,
+    );
+
+    block_storage
+        .save(
+            1235,
+            create_test_ui_confirmed_block(1235),
+            solana_sdk::commitment_config::CommitmentLevel::Confirmed,
+        )
+        .await;
+    block_storage
+        .save(
+            1236,
+            create_test_ui_confirmed_block(1236),
+            solana_sdk::commitment_config::CommitmentLevel::Confirmed,
+        )
+        .await;
+
+    assert!(block_storage.get(1235).await.is_some());
+    assert!(block_storage.get(1236).await.is_some());
+    assert!(persistent_store.get(1235).await.is_none());
+    assert!(persistent_store.get(1236).await.is_none());
+
+    block_storage
+        .save(
+            1235,
+            create_test_ui_confirmed_block(1235),
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+        )
+        .await;
+    block_storage
+        .save(
+            1236,
+            create_test_ui_confirmed_block(1236),
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+        )
+        .await;
+    block_storage
+        .save(
+            1237,
+            create_test_ui_confirmed_block(1237),
+            solana_sdk::commitment_config::CommitmentLevel::Finalized,
+        )
+        .await;
+
+    assert!(block_storage.get(1235).await.is_some());
+    assert!(block_storage.get(1236).await.is_some());
+    assert!(block_storage.get(1237).await.is_some());
+    assert!(persistent_store.get(1235).await.is_some());
+    assert!(persistent_store.get(1236).await.is_some());
+    assert!(persistent_store.get(1237).await.is_some());
+    assert!(block_storage.get_in_memory_block(1237).await.is_some());
+
+    // blocks are replaced by finalized blocks
+    assert_eq!(
+        persistent_store.get(1235).await.unwrap().blockhash,
+        block_storage
+            .get_in_memory_block(1235)
+            .await
+            .unwrap()
+            .blockhash
+    );
+    assert_eq!(
+        persistent_store.get(1236).await.unwrap().blockhash,
+        block_storage
+            .get_in_memory_block(1236)
+            .await
+            .unwrap()
+            .blockhash
+    );
+    assert_eq!(
+        persistent_store.get(1237).await.unwrap().blockhash,
+        block_storage
+            .get_in_memory_block(1237)
+            .await
+            .unwrap()
+            .blockhash
+    );
+
+    // no block yet added returns none
+    assert!(block_storage.get(1238).await.is_none());
+}

--- a/tests/workers.rs
+++ b/tests/workers.rs
@@ -34,7 +34,7 @@ async fn send_and_confirm_txs() {
     let tpu_client = Arc::new(tpu_service.clone());
 
     let tx_sender = TxSender::new(txs_sent_store, tpu_client);
-    let block_store = BlockStore::new(&rpc_client).await.unwrap();
+    let block_storage = BlockStore::new(&rpc_client).await.unwrap();
 
     let block_listener = BlockListener::new(rpc_client.clone(), tx_sender.clone(), block_store);
 


### PR DESCRIPTION
Implementing getBlocks,
Replacing block_store to block_information_store.
Implementing inmemory block store.
Implementing mixed_strategy to fetch block, For few blocks fetch from in memory, for more than that either from persistent block storage or from faithful.