### PR TITLE
Base interface def

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,7 @@ name = "history"
 version = "0.2.2"
 dependencies = [
  "futures",
+ "solana-sdk",
  "solana-transaction-status",
  "tokio",
 ]
@@ -3836,6 +3837,7 @@ dependencies = [
  "solana-lite-rpc-core",
  "solana-transaction-status",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +408,60 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "autotools"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -719,7 +795,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -778,6 +854,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
+name = "cluster"
+version = "0.2.2"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +893,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "consensus"
+version = "0.2.2"
+dependencies = [
+ "futures",
+ "futures-util",
+ "log",
+ "solana-lite-rpc-core",
+ "solana-sdk",
+ "solana-transaction-status",
+ "thiserror",
+ "tokio",
+ "yellowstone-grpc-client",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -1374,6 +1470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,16 +1509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
-name = "fan"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73353b3e9d86ba3d1f2cb930cc04e951ffce0a011877dea8db3f4f9c7ced502f"
-dependencies = [
- "futures",
- "tokio",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1522,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1698,7 +1796,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1731,6 +1829,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -1767,6 +1871,15 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
+name = "history"
+version = "0.2.2"
+dependencies = [
+ "futures",
+ "solana-transaction-status",
+ "tokio",
+]
 
 [[package]]
 name = "hmac"
@@ -1891,6 +2004,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +2079,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2382,6 +2517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2617,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -2842,6 +2989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.0.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3139,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,10 +3201,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
+]
 
 [[package]]
 name = "qstring"
@@ -3599,6 +3829,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
+name = "sendtx"
+version = "0.2.2"
+dependencies = [
+ "futures",
+ "solana-lite-rpc-core",
+ "solana-transaction-status",
+ "tokio",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,7 +4153,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "indicatif",
  "log",
  "quinn",
@@ -3960,7 +4200,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "rand 0.7.3",
  "rayon",
@@ -4031,6 +4271,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
+ "itertools",
  "log",
  "quinn",
  "rustls 0.20.8",
@@ -4064,7 +4305,6 @@ dependencies = [
  "clap 4.2.4",
  "dashmap",
  "dotenv",
- "fan",
  "futures",
  "itertools",
  "lazy_static",
@@ -4552,7 +4792,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "histogram",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "libc",
  "log",
@@ -4599,7 +4839,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "indicatif",
  "log",
  "rand 0.7.3",
@@ -4821,6 +5061,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "stream"
+version = "0.2.2"
+dependencies = [
+ "anyhow",
+ "consensus",
+ "futures",
+ "history",
+ "log",
+ "sendtx",
+ "solana-lite-rpc-core",
+ "solana-sdk",
+ "solana-transaction-status",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4880,6 +5138,12 @@ dependencies = [
  "quote 1.0.26",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -5052,6 +5316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5126,6 +5400,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5180,9 +5455,68 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "nom8",
  "toml_datetime",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.24.0",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.56",
+ "prost-build",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080964d45894b90273d2b1dd755fdd114560db8636bb41cea615213c45043c4d"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]
@@ -5193,8 +5527,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5575,6 +5914,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5795,6 +6145,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time 0.3.20",
+]
+
+[[package]]
+name = "yellowstone-grpc-client"
+version = "1.9.0+solana.1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "638fc820f10c6d836732d43f7c8f93a85301a7d90705a0db38b3bc11fc6657f6"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "thiserror",
+ "tonic",
+ "tonic-health",
+ "yellowstone-grpc-proto",
+]
+
+[[package]]
+name = "yellowstone-grpc-proto"
+version = "1.9.0+solana.1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b29533f1a9486a84b2ffc1fc53d19607af3b71e0554dbde38a841b72026be6"
+dependencies = [
+ "anyhow",
+ "prost",
+ "protobuf-src",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,12 @@ members = [
     "lite-rpc",
     "quic-forward-proxy",
     "quic-forward-proxy-integration-test",
-    "bench"
+    "bench",
+    "allinonerpc",
+    "modules/cluster",
+    "modules/consensus",
+    "modules/history",
+    "modules/sendtx"
 ]
 
 [workspace.package]

--- a/allinonerpc/Cargo.toml
+++ b/allinonerpc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "stream"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-transaction-status = { workspace = true }
+solana-sdk = { workspace = true }
+solana-lite-rpc-core = { workspace = true }
+anyhow = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+
+tokio = { version = "1.*", features = ["macros"] }
+tokio-stream = { version = "0.1.*", features = ["sync"] }
+
+history = {path = "../modules/history"}
+consensus = {path = "../modules/consensus"}
+sendtx = {path = "../modules/sendtx"}

--- a/allinonerpc/src/main.rs
+++ b/allinonerpc/src/main.rs
@@ -1,0 +1,54 @@
+use crate::stream::BlockInfokStreamConnector;
+use crate::stream::FullblockStreamConnector;
+use crate::stream::SlotStreamConnector;
+use tokio_stream::StreamExt;
+
+mod stream;
+
+const GRPC_URL: &str = "http://127.0.0.0:10000";
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 8)]
+pub async fn main() -> anyhow::Result<()> {
+    //slot connector
+    let slot_connector = SlotStreamConnector::new(100);
+    let slot_notifier = slot_connector.get_sender();
+    //convert broadcast to a sink
+    let (slot_sender, mut slot_receiver) = futures::channel::mpsc::unbounded::<u64>();
+    tokio::spawn(async move {
+        while let Some(slot) = slot_receiver.next().await {
+            if let Err(err) = slot_notifier.send(slot) {
+                log::error!("Error during slot broadcast from sink:{err}");
+            }
+        }
+    });
+
+    let block_stream = FullblockStreamConnector::new();
+    let block_sink = block_stream.get_sender_sink();
+    let block_info_stream = BlockInfokStreamConnector::new();
+    let block_info_sink = block_info_stream.get_sender_sink();
+    let history_handle = history::start_module(block_stream.subscribe()).await;
+    let send_tx_handle = sendtx::start_module(block_info_stream.subscribe()).await;
+    let consensus_handle = consensus::start_module(
+        GRPC_URL.to_string(),
+        slot_sender,
+        block_sink,
+        block_info_sink,
+    )
+    .await;
+
+    tokio::select! {
+        err = history_handle => {
+            // This should never happen
+            unreachable!("{err:?}")
+        }
+        err = consensus_handle => {
+            // This should never happen
+            unreachable!("{err:?}")
+        }
+        err = send_tx_handle => {
+            // This should never happen
+            unreachable!("{err:?}")
+        }
+
+    }
+}

--- a/allinonerpc/src/stream.rs
+++ b/allinonerpc/src/stream.rs
@@ -1,0 +1,117 @@
+use futures::channel::mpsc::SendError as FuturesSendError;
+use futures::{channel::mpsc, sink::Sink, stream::Stream};
+use solana_lite_rpc_core::block_store::BlockInformation;
+use solana_sdk::epoch_info::EpochInfo;
+use solana_transaction_status::EncodedConfirmedBlock;
+use thiserror::Error;
+use tokio::sync::broadcast::Sender as BroadcastSender;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tokio_stream::wrappers::BroadcastStream;
+
+#[derive(Debug, Error)]
+pub enum StreamError {
+    #[error("Error during during send slot '{0}'")]
+    SendSlotError(String),
+}
+
+pub type Slot = u64;
+
+macro_rules! create_stream {
+    ($connector_name:ident,$connector_sender:ident, $stream_data:ident) => {
+        pub struct $connector_name {
+            data_receiver: mpsc::UnboundedReceiver<$stream_data>,
+            data_sender: mpsc::UnboundedSender<$stream_data>,
+        }
+        impl $connector_name {
+            pub fn new() -> Self {
+                let (data_sender, data_receiver) = mpsc::unbounded();
+
+                Self {
+                    data_receiver,
+                    data_sender,
+                }
+            }
+
+            pub fn subscribe(self) -> impl Stream<Item = $stream_data> {
+                self.data_receiver
+            }
+
+            //return an error if the fullblock subscription hasn't been done.
+            pub fn get_sender_sink(&self) -> impl Sink<$stream_data, Error = FuturesSendError> {
+                self.data_sender.clone()
+            }
+        }
+    };
+}
+
+create_stream!(BlockInfokStreamConnector, BlockInfoSender, BlockInformation);
+create_stream!(
+    FullblockStreamConnector,
+    FullBlockSender,
+    EncodedConfirmedBlock
+);
+create_stream!(EpochStreamConnector, EpochSender, EpochInfo);
+
+pub struct SlotStreamConnector {
+    slot_sender: BroadcastSender<Slot>,
+}
+
+impl SlotStreamConnector {
+    pub fn new(capacity: usize) -> Self {
+        let (slot_sender, _) = tokio::sync::broadcast::channel::<Slot>(capacity);
+
+        SlotStreamConnector { slot_sender }
+    }
+
+    pub fn subscribe_slot(&mut self) -> impl Stream<Item = Result<Slot, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.slot_sender.subscribe())
+    }
+
+    pub fn send_slot(&self, slot: Slot) -> anyhow::Result<()> {
+        Ok(self.slot_sender.send(slot).map(|_| ())?)
+    }
+
+    pub fn get_sender(&self) -> BroadcastSender<Slot> {
+        self.slot_sender.clone()
+    }
+}
+
+// pub struct FullblockStreamConnector {
+//     fullblock_receiver: UnboundedReceiver<EncodedConfirmedBlock>,
+//     fullblock_sender: UnboundedSender<EncodedConfirmedBlock>,
+// }
+
+// impl FullblockStreamConnector {
+//     pub fn new() -> Self {
+//         let (fullblock_sender, fullblock_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+//         FullblockStreamConnector {
+//             fullblock_receiver,
+//             fullblock_sender,
+//         }
+//     }
+
+//     pub fn subscribe_fullblock(self) -> impl Stream<Item = EncodedConfirmedBlock> {
+//         UnboundedReceiverStream::new(self.fullblock_receiver)
+//     }
+
+//     //return an error if the fullblock subscription hasn't been done.
+//     pub fn get_block_sender(&self) -> FullBlockSender {
+//         FullBlockSender {
+//             sender: self.fullblock_sender.clone(),
+//         }
+//     }
+// }
+
+// #[derive(Debug, Clone)]
+// pub struct FullBlockSender {
+//     sender: UnboundedSender<EncodedConfirmedBlock>,
+// }
+
+// impl FullBlockSender {
+//     pub fn send_fullblock(&self, block: EncodedConfirmedBlock) {
+//         if let Err(err) = self.sender.send(block) {
+//             log::error!("Send block fail cause:{err}");
+//         }
+//     }
+// }

--- a/allinonerpc/src/stream.rs
+++ b/allinonerpc/src/stream.rs
@@ -63,7 +63,7 @@ impl SlotStreamConnector {
         SlotStreamConnector { slot_sender }
     }
 
-    pub fn subscribe_slot(&mut self) -> impl Stream<Item = Result<Slot, BroadcastStreamRecvError>> {
+    pub fn subscribe_slot(&self) -> impl Stream<Item = Result<Slot, BroadcastStreamRecvError>> {
         BroadcastStream::new(self.slot_sender.subscribe())
     }
 

--- a/modules/cluster/Cargo.toml
+++ b/modules/cluster/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cluster"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/modules/cluster/src/lib.rs
+++ b/modules/cluster/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/modules/consensus/Cargo.toml
+++ b/modules/consensus/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "consensus"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-transaction-status = { workspace = true }
+solana-sdk = { workspace = true }
+tokio = { version = "1.*" }
+futures = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+
+
+yellowstone-grpc-client = "1.8.0+solana.1.16.1"
+yellowstone-grpc-proto = "1.8.0+solana.1.16.1"
+
+futures-util = "0.3.28"
+
+solana-lite-rpc-core = { workspace = true }

--- a/modules/consensus/src/lib.rs
+++ b/modules/consensus/src/lib.rs
@@ -3,6 +3,7 @@ use futures::Sink;
 use futures::SinkExt;
 use futures_util::StreamExt;
 use solana_lite_rpc_core::block_store::BlockInformation;
+use solana_sdk::epoch_info::EpochInfo;
 use solana_transaction_status::EncodedConfirmedBlock;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -36,6 +37,7 @@ pub async fn start_module(
     block_info_sinck: impl Sink<BlockInformation, Error = FuturesSendError>
         + std::marker::Send
         + 'static,
+    epoch_sinck: impl Sink<EpochInfo, Error = FuturesSendError> + std::marker::Send + 'static,
 ) -> JoinHandle<Result<(), HistoryError>> {
     let handle = tokio::spawn(async move {
         pin!(full_block_sinck);
@@ -107,6 +109,9 @@ pub async fn start_module(
                                         Some(UpdateOneof::Account(account)) => {
                                         }
                                         Some(UpdateOneof::Slot(slot)) => {
+                                            //convert slot and send on slot sink.
+
+                                            //at epoch change send new epoch on epoch sink.
                                         }
                                         Some(UpdateOneof::Ping(_)) => (),
                                         bad_msg => {

--- a/modules/consensus/src/lib.rs
+++ b/modules/consensus/src/lib.rs
@@ -30,14 +30,12 @@ pub enum HistoryError {
 
 pub async fn start_module(
     grpc_url: String,
-    slot_sinck: impl Sink<u64, Error = FuturesSendError> + std::marker::Send + 'static,
-    full_block_sinck: impl Sink<EncodedConfirmedBlock, Error = FuturesSendError>
+    slot_sink: impl Sink<u64, Error = FuturesSendError> + std::marker::Send + 'static,
+    full_block_sink: impl Sink<EncodedConfirmedBlock, Error = FuturesSendError>
         + std::marker::Send
         + 'static,
-    block_info_sinck: impl Sink<BlockInformation, Error = FuturesSendError>
-        + std::marker::Send
-        + 'static,
-    epoch_sinck: impl Sink<EpochInfo, Error = FuturesSendError> + std::marker::Send + 'static,
+    block_info_sink: impl Sink<BlockInformation, Error = FuturesSendError> + std::marker::Send + 'static,
+    epoch_sink: impl Sink<EpochInfo, Error = FuturesSendError> + std::marker::Send + 'static,
 ) -> JoinHandle<Result<(), HistoryError>> {
     let handle = tokio::spawn(async move {
         pin!(full_block_sinck);

--- a/modules/consensus/src/lib.rs
+++ b/modules/consensus/src/lib.rs
@@ -1,0 +1,167 @@
+use futures::channel::mpsc::SendError as FuturesSendError;
+use futures::Sink;
+use futures::SinkExt;
+use futures_util::StreamExt;
+use solana_lite_rpc_core::block_store::BlockInformation;
+use solana_transaction_status::EncodedConfirmedBlock;
+use std::collections::HashMap;
+use thiserror::Error;
+use tokio::pin;
+use tokio::task::JoinHandle;
+use yellowstone_grpc_client::GeyserGrpcClient;
+use yellowstone_grpc_client::GeyserGrpcClientError;
+use yellowstone_grpc_proto::geyser::CommitmentLevel;
+use yellowstone_grpc_proto::prelude::SubscribeRequestFilterAccounts;
+use yellowstone_grpc_proto::prelude::SubscribeRequestFilterBlocks;
+use yellowstone_grpc_proto::prelude::{subscribe_update::UpdateOneof, SubscribeRequestFilterSlots};
+
+#[derive(Debug, Error)]
+pub enum HistoryError {
+    #[error("Error during during send slot '{0}'")]
+    SendSlotError(String),
+
+    #[error("IO Error during history processing '{0}'")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Geyser Error during history processing '{0}'")]
+    GeyserError(#[from] GeyserGrpcClientError),
+}
+
+pub async fn start_module(
+    grpc_url: String,
+    slot_sinck: impl Sink<u64, Error = FuturesSendError> + std::marker::Send + 'static,
+    full_block_sinck: impl Sink<EncodedConfirmedBlock, Error = FuturesSendError>
+        + std::marker::Send
+        + 'static,
+    block_info_sinck: impl Sink<BlockInformation, Error = FuturesSendError>
+        + std::marker::Send
+        + 'static,
+) -> JoinHandle<Result<(), HistoryError>> {
+    let handle = tokio::spawn(async move {
+        pin!(full_block_sinck);
+        pin!(block_info_sinck);
+
+        //subscribe Geyser grpc
+        let mut slots = HashMap::new();
+        slots.insert("client".to_string(), SubscribeRequestFilterSlots {});
+
+        let mut accounts: HashMap<String, SubscribeRequestFilterAccounts> = HashMap::new();
+
+        accounts.insert(
+            "client".to_owned(),
+            SubscribeRequestFilterAccounts {
+                account: vec![],
+                owner: vec![
+                    solana_sdk::stake::program::ID.to_string(),
+                    solana_sdk::vote::program::ID.to_string(),
+                ],
+                filters: vec![],
+            },
+        );
+
+        let mut blocks = HashMap::new();
+        blocks.insert(
+            "client".to_string(),
+            SubscribeRequestFilterBlocks {
+                account_include: vec![], //vec![SYSTEM_PROGRAM.to_string()],
+                include_transactions: Some(true),
+                include_accounts: None,
+                include_entries: None,
+            },
+        );
+
+        let mut client = GeyserGrpcClient::connect(grpc_url, None::<&'static str>, None)?;
+        let mut confirmed_stream = client
+            .subscribe_once(
+                slots,
+                accounts,           //accounts
+                Default::default(), //tx
+                Default::default(), //entry
+                blocks,             //full block
+                Default::default(), //block meta
+                Some(CommitmentLevel::Confirmed),
+                vec![],
+            )
+            .await?;
+
+        loop {
+            tokio::select! {
+                ret = confirmed_stream.next() => {
+                    match ret {
+                         Some(message) => {
+                            //process the message
+                            match message {
+                                Ok(msg) => {
+                                    //log::info!("new message: {msg:?}");
+                                    match msg.update_oneof {
+                                        Some(UpdateOneof::Block(block)) => {
+                                            let info_block = convert_into_blockinfo(&block);
+                                            if let Err(err) = block_info_sinck.send(info_block).await {
+                                                log::error!("Error during sending block info:{err}");
+                                            }
+                                            let rpc_block = convert_block(block);
+                                            if let Err(err) = full_block_sinck.send(rpc_block).await {
+                                                log::error!("Error during sending full block:{err}");
+                                            }
+                                        }
+                                        Some(UpdateOneof::Account(account)) => {
+                                        }
+                                        Some(UpdateOneof::Slot(slot)) => {
+                                        }
+                                        Some(UpdateOneof::Ping(_)) => (),
+                                        bad_msg => {
+                                            log::info!("Geyser stream unexpected message received:{:?}",bad_msg);
+                                        }
+                                    }
+                                }
+                                Err(error) => {
+                                    log::error!("Geyser stream receive an error has message: {error:?}, try to reconnect and resynchronize.");
+                                    break;
+                                }
+                            }
+                         }
+                         None => {
+                            log::warn!("The geyser stream close try to reconnect and resynchronize.");
+                            break; //TODO reconnect.
+                         }
+                     }
+
+                }
+
+            }
+        }
+
+        Ok(())
+    });
+    handle
+}
+
+fn convert_into_blockinfo(
+    geyser_block: &yellowstone_grpc_proto::geyser::SubscribeUpdateBlock,
+) -> BlockInformation {
+    BlockInformation {
+        slot: geyser_block.slot,
+        block_height: geyser_block
+            .block_height
+            .clone()
+            .map(|h| h.block_height)
+            .unwrap_or(0),
+        last_valid_blockheight: 0,  //PUT INSIDE SENDTX
+        cleanup_slot: 0,            //PUT INSIDE SENDTX
+        processed_local_time: None, //change to u128 timestamp.
+    }
+}
+
+fn convert_block(
+    geyser_block: yellowstone_grpc_proto::geyser::SubscribeUpdateBlock,
+) -> EncodedConfirmedBlock {
+    EncodedConfirmedBlock {
+        previous_blockhash: geyser_block.parent_blockhash,
+        blockhash: geyser_block.blockhash,
+        parent_slot: geyser_block.parent_slot,
+        transactions: vec![], //TODO convert Tx
+        rewards: vec![],
+        block_time: geyser_block.block_time.map(|t| t.timestamp),
+        block_height: geyser_block.block_height.map(|h| h.block_height),
+    }
+}

--- a/modules/history/Cargo.toml
+++ b/modules/history/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "history"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-transaction-status = { workspace = true }
+tokio = { version = "1.*" }
+futures = { workspace = true }
+

--- a/modules/history/Cargo.toml
+++ b/modules/history/Cargo.toml
@@ -10,6 +10,6 @@ edition.workspace = true
 
 [dependencies]
 solana-transaction-status = { workspace = true }
-tokio = { version = "1.*" }
+solana-sdk = { workspace = true }
+tokio = { version = "1.*", features = ["macros"]  }
 futures = { workspace = true }
-

--- a/modules/history/src/lib.rs
+++ b/modules/history/src/lib.rs
@@ -1,0 +1,19 @@
+use futures::stream::Stream;
+use futures::StreamExt;
+use solana_transaction_status::EncodedConfirmedBlock;
+use tokio::pin;
+use tokio::task::JoinHandle;
+
+pub async fn start_module(
+    full_block_steam: impl Stream<Item = EncodedConfirmedBlock> + std::marker::Send + 'static,
+) -> JoinHandle<std::io::Result<()>> {
+    let handle = tokio::spawn(async move {
+        pin!(full_block_steam);
+        while let Some(block) = full_block_steam.next().await {
+            //process block
+        }
+
+        Ok(())
+    });
+    handle
+}

--- a/modules/history/src/lib.rs
+++ b/modules/history/src/lib.rs
@@ -1,19 +1,28 @@
 use futures::stream::Stream;
 use futures::StreamExt;
+use solana_sdk::epoch_info::EpochInfo;
 use solana_transaction_status::EncodedConfirmedBlock;
 use tokio::pin;
 use tokio::task::JoinHandle;
 
 pub async fn start_module(
-    full_block_steam: impl Stream<Item = EncodedConfirmedBlock> + std::marker::Send + 'static,
+    full_block_stream: impl Stream<Item = EncodedConfirmedBlock> + std::marker::Send + 'static,
+    epoch_steam: impl Stream<Item = EpochInfo> + std::marker::Send + 'static,
 ) -> JoinHandle<std::io::Result<()>> {
     let handle = tokio::spawn(async move {
-        pin!(full_block_steam);
-        while let Some(block) = full_block_steam.next().await {
-            //process block
-        }
+        pin!(full_block_stream);
+        pin!(epoch_steam);
 
-        Ok(())
+        loop {
+            tokio::select! {
+                Some(full_block) = full_block_stream.next() => {
+                    //process full block
+                }
+                Some(epoch) = epoch_steam.next() => {
+                    //Process epoch
+                }
+            }
+        }
     });
     handle
 }

--- a/modules/sendtx/Cargo.toml
+++ b/modules/sendtx/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sendtx"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-transaction-status = { workspace = true }
+tokio = { version = "1.*" }
+futures = { workspace = true }
+
+solana-lite-rpc-core = { workspace = true }

--- a/modules/sendtx/Cargo.toml
+++ b/modules/sendtx/Cargo.toml
@@ -14,3 +14,5 @@ tokio = { version = "1.*" }
 futures = { workspace = true }
 
 solana-lite-rpc-core = { workspace = true }
+
+tokio-stream = { version = "0.1.*", features = ["sync"] }

--- a/modules/sendtx/src/lib.rs
+++ b/modules/sendtx/src/lib.rs
@@ -3,17 +3,26 @@ use futures::StreamExt;
 use solana_lite_rpc_core::block_store::BlockInformation;
 use tokio::pin;
 use tokio::task::JoinHandle;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 pub async fn start_module(
     block_info_steam: impl Stream<Item = BlockInformation> + std::marker::Send + 'static,
+    slot_steam: impl Stream<Item = Result<u64, BroadcastStreamRecvError>> + std::marker::Send + 'static,
 ) -> JoinHandle<std::io::Result<()>> {
     let handle = tokio::spawn(async move {
+        pin!(slot_steam);
         pin!(block_info_steam);
-        while let Some(block_info) = block_info_steam.next().await {
-            //process block_info
-        }
 
-        Ok(())
+        loop {
+            tokio::select! {
+                Some(block_info) = block_info_steam.next() => {
+                    //process block_info
+                }
+                Some(slot) = slot_steam.next() => {
+                    //Process slot
+                }
+            }
+        }
     });
     handle
 }

--- a/modules/sendtx/src/lib.rs
+++ b/modules/sendtx/src/lib.rs
@@ -1,0 +1,19 @@
+use futures::stream::Stream;
+use futures::StreamExt;
+use solana_lite_rpc_core::block_store::BlockInformation;
+use tokio::pin;
+use tokio::task::JoinHandle;
+
+pub async fn start_module(
+    block_info_steam: impl Stream<Item = BlockInformation> + std::marker::Send + 'static,
+) -> JoinHandle<std::io::Result<()>> {
+    let handle = tokio::spawn(async move {
+        pin!(block_info_steam);
+        while let Some(block_info) = block_info_steam.next().await {
+            //process block_info
+        }
+
+        Ok(())
+    });
+    handle
+}


### PR DESCRIPTION
This is an example of the RPC v2 architecture implementation for the Steam part.
An all-in-one process implementation is done in `allinonerpc` crate that implements the stream logic for in process.
A module is defined for each domain. Each domain get a Stream or Sink (depending on if it's a produced or a consumer) and process them.
I put some example for Block, BlockInfo, Slot and Epoch in each module depending on the stream defined in the spec: https://github.com/blockworks-foundation/lite-rpc/blob/rpc_doc/docs/architecture.md.
It can help to understand the main stream architecture.
The RPC part is missing. Each module implement its own RPC entry point.