### PR TITLE
bench: support large transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,11 +574,13 @@ name = "bench"
 version = "0.2.3"
 dependencies = [
  "anyhow",
+ "bincode",
  "clap 4.4.2",
  "csv",
  "dashmap",
  "dirs",
  "futures",
+ "itertools",
  "lazy_static",
  "log",
  "rand 0.8.5",
@@ -587,6 +589,7 @@ dependencies = [
  "serde_json",
  "solana-rpc-client",
  "solana-sdk",
+ "spl-memo 4.0.0",
  "tokio",
  "tracing-subscriber",
 ]
@@ -4337,7 +4340,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "solana-transaction-status",
- "spl-memo",
+ "spl-memo 3.0.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -4379,7 +4382,7 @@ dependencies = [
  "solana-sdk",
  "solana-streamer",
  "solana-transaction-status",
- "spl-memo",
+ "spl-memo 3.0.1",
  "thiserror",
  "tokio",
  "tracing-subscriber",
@@ -4893,7 +4896,7 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-sdk",
  "spl-associated-token-account",
- "spl-memo",
+ "spl-memo 3.0.1",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -5042,6 +5045,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-memo"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "spl-token"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5069,7 +5081,7 @@ dependencies = [
  "num_enum 0.5.11",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo",
+ "spl-memo 3.0.1",
  "spl-token",
  "thiserror",
 ]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -20,4 +20,9 @@ rand_chacha = "0.3.1"
 futures = { workspace = true }
 dashmap = { workspace = true }
 lazy_static = "1.4.0"
+bincode = { workspace = true }
+itertools = "0.10.5"
+spl-memo = "4.0.0"
 
+[dev-dependencies]
+bincode = { workspace = true }

--- a/bench/src/cli.rs
+++ b/bench/src/cli.rs
@@ -20,6 +20,7 @@ pub struct Args {
     pub lite_rpc_addr: String,
     #[arg(short = 't', long, default_value_t = String::from("transactions.csv"))]
     pub transaction_save_file: String,
+    // choose between small (179 bytes) and large (1186 bytes) transactions
     #[arg(short = 'L', long, default_value_t = false)]
     pub large_transactions: bool,
 }

--- a/bench/src/cli.rs
+++ b/bench/src/cli.rs
@@ -20,4 +20,6 @@ pub struct Args {
     pub lite_rpc_addr: String,
     #[arg(short = 't', long, default_value_t = String::from("transactions.csv"))]
     pub transaction_save_file: String,
+    #[arg(short = 'L', long, default_value_t = false)]
+    pub large_transactions: bool,
 }

--- a/bench/src/helpers.rs
+++ b/bench/src/helpers.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
+use itertools::Itertools;
 use lazy_static::lazy_static;
 use rand::{distributions::Alphanumeric, prelude::Distribution, SeedableRng};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::instruction::AccountMeta;
 use solana_sdk::{
     commitment_config::CommitmentConfig,
     hash::Hash,
@@ -75,11 +77,15 @@ impl BenchHelper {
         Transaction::new(&[funded_payer], message, blockhash)
     }
 
-    pub fn generate_random_strings(num_of_txs: usize, random_seed: Option<u64>) -> Vec<Vec<u8>> {
+    pub fn generate_random_strings(
+        num_of_txs: usize,
+        random_seed: Option<u64>,
+        n_chars: usize,
+    ) -> Vec<Vec<u8>> {
         let seed = random_seed.map_or(0, |x| x);
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
         (0..num_of_txs)
-            .map(|_| Alphanumeric.sample_iter(&mut rng).take(10).collect())
+            .map(|_| Alphanumeric.sample_iter(&mut rng).take(n_chars).collect())
             .collect()
     }
 
@@ -96,16 +102,67 @@ impl BenchHelper {
             .map(|_| {
                 let random_bytes: Vec<u8> = Alphanumeric.sample_iter(&mut rng).take(10).collect();
 
-                Self::create_memo_tx(&random_bytes, funded_payer, blockhash)
+                Self::create_memo_tx_small(&random_bytes, funded_payer, blockhash)
             })
             .collect()
     }
 
-    pub fn create_memo_tx(msg: &[u8], payer: &Keypair, blockhash: Hash) -> Transaction {
+    pub fn create_memo_tx_small(msg: &[u8], payer: &Keypair, blockhash: Hash) -> Transaction {
         let memo = Pubkey::from_str(MEMO_PROGRAM_ID).unwrap();
 
         let instruction = Instruction::new_with_bytes(memo, msg, vec![]);
         let message = Message::new(&[instruction], Some(&payer.pubkey()));
         Transaction::new(&[payer], message, blockhash)
     }
+
+    pub fn create_memo_tx_large(msg: &[u8], payer: &Keypair, blockhash: Hash) -> Transaction {
+        let accounts = (0..8).map(|_| Keypair::new()).collect_vec();
+
+        let memo = Pubkey::from_str(MEMO_PROGRAM_ID).unwrap();
+
+        let instruction = Instruction::new_with_bytes(
+            memo,
+            msg,
+            accounts
+                .iter()
+                .map(|keypair| AccountMeta::new_readonly(keypair.pubkey(), true))
+                .collect_vec(),
+        );
+        let message = Message::new(&[instruction], Some(&payer.pubkey()));
+
+        let mut signers = vec![payer];
+        signers.extend(accounts.iter());
+
+        Transaction::new(&signers, message, blockhash)
+    }
+}
+
+#[test]
+fn transaction_size_small() {
+    let blockhash = Hash::default();
+    let payer_keypair = Keypair::from_base58_string(
+        "rKiJ7H5UUp3JR18kNyTF1XPuwPKHEM7gMLWHZPWP5djrW1vSjfwjhvJrevxF9MPmUmN9gJMLHZdLMgc9ao78eKr",
+    );
+
+    let seed = 42;
+    let random_strings = BenchHelper::generate_random_strings(1, Some(seed), 10);
+    let rand_string = random_strings.get(0).unwrap();
+    let tx = BenchHelper::create_memo_tx_small(rand_string, &payer_keypair, blockhash);
+
+    assert_eq!(bincode::serialized_size(&tx).unwrap(), 179);
+}
+
+#[test]
+fn transaction_size_large() {
+    let blockhash = Hash::default();
+    let payer_keypair = Keypair::from_base58_string(
+        "rKiJ7H5UUp3JR18kNyTF1XPuwPKHEM7gMLWHZPWP5djrW1vSjfwjhvJrevxF9MPmUmN9gJMLHZdLMgc9ao78eKr",
+    );
+
+    let seed = 42;
+    let random_strings = BenchHelper::generate_random_strings(1, Some(seed), 240);
+    let rand_string = random_strings.get(0).unwrap();
+    let tx = BenchHelper::create_memo_tx_large(rand_string, &payer_keypair, blockhash);
+
+    assert_eq!(bincode::serialized_size(&tx).unwrap(), 1186);
 }

--- a/bench/src/metrics.rs
+++ b/bench/src/metrics.rs
@@ -12,9 +12,12 @@ pub struct Metric {
     pub txs_un_confirmed: u64,
     pub average_confirmation_time_ms: f64,
     pub average_time_to_send_txs: f64,
+    pub average_transaction_bytes: f64,
 
     #[serde(skip_serializing)]
     total_sent_time: Duration,
+    #[serde(skip_serializing)]
+    total_transaction_bytes: u64,
     #[serde(skip_serializing)]
     total_confirmation_time: Duration,
 }
@@ -24,16 +27,19 @@ impl Metric {
         &mut self,
         time_to_send: Duration,
         time_to_confrim: Duration,
+        transaction_bytes: u64,
     ) {
         self.total_sent_time += time_to_send;
         self.total_confirmation_time += time_to_confrim;
+        self.total_transaction_bytes += transaction_bytes;
 
         self.txs_confirmed += 1;
         self.txs_sent += 1;
     }
 
-    pub fn add_unsuccessful_transaction(&mut self, time_to_send: Duration) {
+    pub fn add_unsuccessful_transaction(&mut self, time_to_send: Duration, transaction_bytes: u64) {
         self.total_sent_time += time_to_send;
+        self.total_transaction_bytes += transaction_bytes;
         self.txs_un_confirmed += 1;
         self.txs_sent += 1;
     }
@@ -42,6 +48,8 @@ impl Metric {
         if self.txs_sent > 0 {
             self.average_time_to_send_txs =
                 self.total_sent_time.as_millis() as f64 / self.txs_sent as f64;
+            self.average_transaction_bytes =
+                self.total_transaction_bytes as f64 / self.txs_sent as f64;
         }
 
         if self.txs_confirmed > 0 {
@@ -71,6 +79,7 @@ impl AddAssign<&Self> for Metric {
 
         self.total_confirmation_time += rhs.total_confirmation_time;
         self.total_sent_time += rhs.total_sent_time;
+        self.total_transaction_bytes += rhs.total_transaction_bytes;
         self.finalize();
     }
 }
@@ -89,6 +98,7 @@ impl DivAssign<u64> for Metric {
             Duration::from_micros((self.total_confirmation_time.as_micros() / rhs as u128) as u64);
         self.total_sent_time =
             Duration::from_micros((self.total_sent_time.as_micros() / rhs as u128) as u64);
+        self.total_transaction_bytes = self.total_transaction_bytes / rhs;
         self.finalize();
     }
 }

--- a/quic-forward-proxy-integration-test/tests/quic_proxy_tpu_integrationtest.rs
+++ b/quic-forward-proxy-integration-test/tests/quic_proxy_tpu_integrationtest.rs
@@ -311,7 +311,7 @@ fn wireup_and_send_txs_via_channel(test_case_params: TestCaseParams) {
                 count_map.insert_or_increment(*tx.get_signature());
             }
 
-            if packet_count == warmup_tx_count {
+            if timer2.is_none() && packet_count >= warmup_tx_count {
                 timer2 = Some(Instant::now());
             }
         } // -- while not all packets received - by count


### PR DESCRIPTION
Problem:
The rust bench tool used small transactions of only 179 bytes which is unrealistic.

Proposed Solution:
Add option to allow for large transactions:
`cargo run --bin bench -- --tx-count=10 |--large-transactions` (short `-L`)

transaction characteristics:
* uses memo [program](https://spl.solana.com/memo)
* 1186 bytes
* 8 account signatures
* 240 utf-chars in memo progra
* 193175 compute units

Added transaction size to metrics:

> 2023-09-29T12:27:47.830548Z  INFO bench: Run 1: Sent and Confirmed 10 tx(s) in Metric { txs_sent: 10, txs_confirmed: 10, txs_un_confirmed: 0, average_confirmation_time_ms: 546.8, average_time_to_send_txs: 0.8, average_transaction_bytes: 179.0, total_sent_time: 8.482915ms, total_transaction_bytes: 1790, total_confirmation_time: 5.468757417s } with    
2023-09-29T12:27:47.830752Z  INFO bench: Run 2: Sent and Confirmed 10 tx(s) in Metric { txs_sent: 10, txs_confirmed: 10, txs_un_confirmed: 0, average_confirmation_time_ms: 545.8, average_time_to_send_txs: 0.9, average_transaction_bytes: 179.0, total_sent_time: 9.194709ms, total_transaction_bytes: 1790, total_confirmation_time: 5.458955708s } with    
2023-09-29T12:27:47.830773Z  INFO bench: Run 3: Sent and Confirmed 10 tx(s) in Metric { txs_sent: 10, txs_confirmed: 10, txs_un_confirmed: 0, average_confirmation_time_ms: 551.6, average_time_to_send_txs: 1.0, average_transaction_bytes: 179.0, total_sent_time: 10.259458ms, total_transaction_bytes: 1790, total_confirmation_time: 5.516048292s } with    
2023-09-29T12:27:47.830786Z  INFO bench: Avg Metric Metric { txs_sent: 10, txs_confirmed: 10, txs_un_confirmed: 0, average_confirmation_time_ms: 548.1, average_time_to_send_txs: 0.9, average_transaction_bytes: 179.0, total_sent_time: 9.312ms, total_transaction_bytes: 1790, total_confirmation_time: 5.481253s }   
