### PR TITLE
Stakes and votes management: add leader schedule calculus

### DIFF
--- a/core/src/structures/leaderschedule.rs
+++ b/core/src/structures/leaderschedule.rs
@@ -1,8 +1,6 @@
 use crate::stores::block_information_store::BlockInformation;
 use crate::stores::data_cache::DataCache;
 use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::vote::state::VoteState;
 use std::collections::HashMap;
 
 #[derive(Clone, Default)]
@@ -43,6 +41,5 @@ impl CalculatedSchedule {
 #[derive(Clone)]
 pub struct LeaderScheduleData {
     pub schedule: HashMap<String, Vec<usize>>,
-    pub vote_stakes: HashMap<Pubkey, (u64, VoteState)>,
     pub epoch: u64,
 }

--- a/stake_vote/src/leader_schedule.rs
+++ b/stake_vote/src/leader_schedule.rs
@@ -106,8 +106,8 @@ fn process_leadershedule_event(
                 VoteStore::take_votestore(votestore),
             ) {
                 (Ok((stake_map, mut stake_history)), Ok(vote_map)) => {
-                    //For test TODO put in extract and restore process to avoid to clone.
                     log::info!("LeaderScheduleEvent::CalculateScedule");
+                    //do the calculus in a blocking task.
                     let jh = tokio::task::spawn_blocking({
                         move || {
                             let next_epoch = current_epoch + 1;

--- a/stake_vote/src/leader_schedule.rs
+++ b/stake_vote/src/leader_schedule.rs
@@ -1,31 +1,287 @@
-use crate::stake::StakeMap;
-use crate::stake::StakeStore;
-use crate::vote::VoteMap;
-use crate::vote::VoteStore;
+use crate::stake::{StakeMap, StakeStore};
+use crate::vote::StoredVote;
+use crate::vote::{VoteMap, VoteStore};
 use futures::stream::FuturesUnordered;
-use solana_lite_rpc_core::structures::leaderschedule::LeaderScheduleData;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use solana_client::rpc_client::RpcClient;
+use solana_ledger::leader_schedule::LeaderSchedule;
 use solana_program::sysvar::epoch_schedule::EpochSchedule;
+use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::feature_set::FeatureSet;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::stake::state::StakeActivationStatus;
 use solana_sdk::stake_history::StakeHistory;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+pub struct LeaderScheduleGeneratedData {
+    pub schedule: HashMap<String, Vec<usize>>,
+    pub vote_stakes: HashMap<Pubkey, (u64, Arc<StoredVote>)>,
+    pub epoch: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EpochStake {
+    epoch: u64,
+    stake_vote_map: HashMap<Pubkey, (u64, Arc<StoredVote>)>,
+}
+
+/*
+Leader schedule calculus state diagram
+
+InitLeaderschedule
+       |
+   |extract store stake and vote|
+     |                   |
+   Error          CalculateScedule(stakes, votes)
+     |                   |
+ | Wait(1s)|       |Calculate schedule|
+     |                       |
+InitLeaderscedule        MergeStore(stakes, votes, schedule)
+                             |                      |
+                           Error                   SaveSchedule(schedule)
+                             |                              |
+              |never occurs restart (wait 1s)|         |save schedule and verify (opt)|
+                             |
+                      InitLeaderscedule
+*/
 
 pub enum LeaderScheduleEvent {
     Init(u64, u64, Option<solana_sdk::clock::Epoch>),
     MergeStoreAndSaveSchedule(
         StakeMap,
         VoteMap,
-        LeaderScheduleData,
-        (u64, u64, Arc<EpochSchedule>),
+        LeaderScheduleGeneratedData,
+        (u64, u64, Option<solana_sdk::clock::Epoch>),
         Option<StakeHistory>,
     ),
+}
+
+enum LeaderScheduleResult {
+    TaskHandle(JoinHandle<LeaderScheduleEvent>),
+    Event(LeaderScheduleEvent),
+    End(LeaderScheduleGeneratedData),
 }
 
 //Execute the leader schedule process.
 pub fn run_leader_schedule_events(
     event: LeaderScheduleEvent,
-    bootstrap_tasks: &mut FuturesUnordered<JoinHandle<LeaderScheduleEvent>>,
+    schedule_tasks: &mut FuturesUnordered<JoinHandle<LeaderScheduleEvent>>,
     stakestore: &mut StakeStore,
     votestore: &mut VoteStore,
-) -> Option<LeaderScheduleData> {
-    todo!();
+) -> Option<LeaderScheduleGeneratedData> {
+    let result = process_leadershedule_event(event, stakestore, votestore);
+    match result {
+        LeaderScheduleResult::TaskHandle(jh) => {
+            schedule_tasks.push(jh);
+            None
+        }
+        LeaderScheduleResult::Event(event) => {
+            run_leader_schedule_events(event, schedule_tasks, stakestore, votestore)
+        }
+        LeaderScheduleResult::End(schedule) => Some(schedule),
+    }
+}
+
+fn process_leadershedule_event(
+    //    rpc_url: String,
+    event: LeaderScheduleEvent,
+    stakestore: &mut StakeStore,
+    votestore: &mut VoteStore,
+) -> LeaderScheduleResult {
+    match event {
+        LeaderScheduleEvent::Init(current_epoch, slots_in_epoch, new_rate_activation_epoch) => {
+            match (
+                StakeStore::take_stakestore(stakestore),
+                VoteStore::take_votestore(votestore),
+            ) {
+                (Ok((stake_map, mut stake_history)), Ok(vote_map)) => {
+                    //For test TODO put in extract and restore process to avoid to clone.
+                    log::info!("LeaderScheduleEvent::CalculateScedule");
+                    let jh = tokio::task::spawn_blocking({
+                        move || {
+                            let next_epoch = current_epoch + 1;
+                            let epoch_vote_stakes = calculate_epoch_stakes(
+                                &stake_map,
+                                &vote_map,
+                                current_epoch,
+                                next_epoch,
+                                stake_history.as_mut(),
+                                new_rate_activation_epoch,
+                            );
+
+                            let leader_schedule = calculate_leader_schedule(
+                                &epoch_vote_stakes,
+                                next_epoch,
+                                slots_in_epoch,
+                            );
+                            log::info!("End calculate leader schedule");
+                            LeaderScheduleEvent::MergeStoreAndSaveSchedule(
+                                stake_map,
+                                vote_map,
+                                LeaderScheduleGeneratedData {
+                                    schedule: leader_schedule,
+                                    vote_stakes: epoch_vote_stakes,
+                                    epoch: next_epoch,
+                                },
+                                (current_epoch, slots_in_epoch, new_rate_activation_epoch),
+                                stake_history,
+                            )
+                        }
+                    });
+                    LeaderScheduleResult::TaskHandle(jh)
+                }
+                _ => {
+                    log::error!("Create leadershedule init event error during extract store");
+                    LeaderScheduleResult::Event(LeaderScheduleEvent::Init(
+                        current_epoch,
+                        slots_in_epoch,
+                        new_rate_activation_epoch,
+                    ))
+                }
+            }
+        }
+        LeaderScheduleEvent::MergeStoreAndSaveSchedule(
+            stake_map,
+            vote_map,
+            schedule_data,
+            (current_epoch, slots_in_epoch, epoch_schedule),
+            stake_history,
+        ) => {
+            log::info!("LeaderScheduleEvent::MergeStoreAndSaveSchedule RECV");
+            match (
+                StakeStore::merge_stakestore(stakestore, stake_map, stake_history),
+                VoteStore::merge_votestore(votestore, vote_map),
+            ) {
+                (Ok(()), Ok(())) => LeaderScheduleResult::End(schedule_data),
+                _ => {
+                    //this shoud never arrive because the store has been extracted before.
+                    //TODO remove this error using type state
+                    log::warn!("LeaderScheduleEvent::MergeStoreAndSaveSchedule merge stake or vote fail, -restart Schedule");
+                    LeaderScheduleResult::Event(LeaderScheduleEvent::Init(
+                        current_epoch,
+                        slots_in_epoch,
+                        epoch_schedule,
+                    ))
+                }
+            }
+        }
+    }
+}
+
+fn calculate_epoch_stakes(
+    stake_map: &StakeMap,
+    vote_map: &VoteMap,
+    current_epoch: u64,
+    next_epoch: u64,
+    mut stake_history: Option<&mut StakeHistory>,
+    new_rate_activation_epoch: Option<solana_sdk::clock::Epoch>,
+) -> HashMap<Pubkey, (u64, Arc<StoredVote>)> {
+    //update stake history with current end epoch stake values.
+    let stake_history_entry =
+        stake_map
+            .values()
+            .fold(StakeActivationStatus::default(), |acc, stake_account| {
+                let delegation = stake_account.stake;
+                acc + delegation.stake_activating_and_deactivating(
+                    current_epoch,
+                    stake_history.as_deref(),
+                    new_rate_activation_epoch,
+                )
+            });
+    match stake_history {
+        Some(ref mut stake_history) => stake_history.add(current_epoch, stake_history_entry),
+        None => log::warn!("Vote stake calculus without Stake History"),
+    };
+
+    //calculate schedule stakes.
+    let delegated_stakes: HashMap<Pubkey, u64> =
+        stake_map
+            .values()
+            .fold(HashMap::default(), |mut delegated_stakes, stake_account| {
+                let delegation = stake_account.stake;
+                let entry = delegated_stakes.entry(delegation.voter_pubkey).or_default();
+                *entry += delegation.stake(
+                    next_epoch,
+                    stake_history.as_deref(),
+                    new_rate_activation_epoch,
+                );
+                delegated_stakes
+            });
+
+    let staked_vote_map: HashMap<Pubkey, (u64, Arc<StoredVote>)> = vote_map
+        .values()
+        .map(|vote_account| {
+            let delegated_stake = delegated_stakes
+                .get(&vote_account.pubkey)
+                .copied()
+                .unwrap_or_else(|| {
+                    log::info!(
+                        "calculate_epoch_stakes stake with no vote account:{}",
+                        vote_account.pubkey
+                    );
+                    Default::default()
+                });
+            (vote_account.pubkey, (delegated_stake, vote_account.clone()))
+        })
+        .collect();
+    staked_vote_map
+}
+
+//Copied from leader_schedule_utils.rs
+// Mostly cribbed from leader_schedule_utils
+fn calculate_leader_schedule(
+    stake_vote_map: &HashMap<Pubkey, (u64, Arc<StoredVote>)>,
+    epoch: u64,
+    slots_in_epoch: u64,
+) -> HashMap<String, Vec<usize>> {
+    let mut stakes: Vec<(Pubkey, u64)> = stake_vote_map
+        .iter()
+        .filter_map(|(_, (stake, vote_account))| {
+            (*stake > 0).then_some((vote_account.vote_data.node_pubkey, *stake))
+        })
+        .collect();
+
+    let mut seed = [0u8; 32];
+    seed[0..8].copy_from_slice(&epoch.to_le_bytes());
+    sort_stakes(&mut stakes);
+    log::info!("calculate_leader_schedule stakes:{stakes:?} epoch:{epoch}");
+    let schedule = LeaderSchedule::new(&stakes, seed, slots_in_epoch, NUM_CONSECUTIVE_LEADER_SLOTS);
+
+    let slot_schedule = schedule
+        .get_slot_leaders()
+        .iter()
+        .enumerate()
+        .map(|(i, pk)| (pk.to_string(), i))
+        .into_group_map()
+        .into_iter()
+        .collect();
+    slot_schedule
+}
+
+// Cribbed from leader_schedule_utils
+fn sort_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
+    // Sort first by stake. If stakes are the same, sort by pubkey to ensure a
+    // deterministic result.
+    // Note: Use unstable sort, because we dedup right after to remove the equal elements.
+    stakes.sort_unstable_by(|(l_pubkey, l_stake), (r_pubkey, r_stake)| {
+        if r_stake == l_stake {
+            r_pubkey.cmp(l_pubkey)
+        } else {
+            r_stake.cmp(l_stake)
+        }
+    });
+
+    // Now that it's sorted, we can do an O(n) dedup.
+    stakes.dedup();
 }

--- a/stake_vote/src/utils.rs
+++ b/stake_vote/src/utils.rs
@@ -1,7 +1,11 @@
+use anyhow::bail;
 use solana_lite_rpc_core::stores::block_information_store::BlockInformation;
 use solana_lite_rpc_core::stores::data_cache::DataCache;
 use solana_lite_rpc_core::structures::epoch::Epoch as LiteRpcEpoch;
 use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+use std::default::Default;
 
 pub async fn get_current_confirmed_slot(data_cache: &DataCache) -> u64 {
     let commitment = CommitmentConfig::confirmed();
@@ -15,4 +19,135 @@ pub async fn get_current_confirmed_slot(data_cache: &DataCache) -> u64 {
 pub async fn get_current_epoch(data_cache: &DataCache) -> LiteRpcEpoch {
     let commitment = CommitmentConfig::confirmed();
     data_cache.get_current_epoch(commitment).await
+}
+
+//Takable struct code
+pub trait TakableContent<T>: Default {
+    fn add_value(&mut self, val: T);
+}
+
+///A struct that hold a collection call content that can be taken during some time and merged after.
+///During the time the content is taken, new added values are cached and added to the content after the merge.
+///It allow to process struct content while allowing to still update it without lock.
+#[derive(Default, Debug)]
+pub struct TakableMap<T, C: TakableContent<T>> {
+    pub content: C,
+    pub updates: Vec<T>,
+    taken: bool,
+}
+
+impl<T: Default, C: TakableContent<T> + Default> TakableMap<T, C> {
+    pub fn new(content: C) -> Self {
+        TakableMap {
+            content,
+            updates: vec![],
+            taken: false,
+        }
+    }
+
+    //add a value to the content if not taken or put it in the update waiting list.
+    //Use force_in_update to force the insert in update waiting list.
+    pub fn add_value(&mut self, val: T, force_in_update: bool) {
+        //during extract push the new update or
+        //don't insert now account change that has been done in next epoch.
+        //put in update pool to be merged next epoch change.
+        match self.taken || force_in_update {
+            true => self.updates.push(val),
+            false => self.content.add_value(val),
+        }
+    }
+
+    pub fn take(self) -> (Self, C) {
+        let takenmap = TakableMap {
+            content: C::default(),
+            updates: self.updates,
+            taken: true,
+        };
+        (takenmap, self.content)
+    }
+
+    pub fn merge(self, content: C) -> Self {
+        let mut mergedstore = TakableMap {
+            content,
+            updates: vec![],
+            taken: false,
+        };
+
+        //apply stake added during extraction.
+        for val in self.updates {
+            mergedstore.content.add_value(val);
+        }
+        mergedstore
+    }
+
+    pub fn is_taken(&self) -> bool {
+        self.taken
+    }
+}
+
+pub fn take<T: Default, C: TakableContent<T> + Default>(
+    map: &mut TakableMap<T, C>,
+) -> anyhow::Result<C> {
+    if map.is_taken() {
+        bail!("TakableMap already taken. Try later");
+    }
+    let new_store = std::mem::take(map);
+    let (new_store, content) = new_store.take();
+    *map = new_store;
+    Ok(content)
+}
+
+pub fn merge<T: Default, C: TakableContent<T> + Default>(
+    map: &mut TakableMap<T, C>,
+    content: C,
+) -> anyhow::Result<()> {
+    if !map.is_taken() {
+        bail!("TakableMap merge of non taken map. Try later");
+    }
+    let new_store = std::mem::take(map);
+    let new_store = new_store.merge(content);
+    *map = new_store;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_takable_struct() {
+        impl TakableContent<u64> for Vec<u64> {
+            fn add_value(&mut self, val: u64) {
+                self.push(val)
+            }
+        }
+
+        let content: Vec<u64> = vec![];
+        let mut takable = TakableMap::new(content);
+        takable.add_value(23, false);
+        assert_eq!(takable.content.len(), 1);
+
+        takable.add_value(24, true);
+        assert_eq!(takable.content.len(), 1);
+        assert_eq!(takable.updates.len(), 1);
+
+        let content = take(&mut takable).unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(takable.content.len(), 0);
+        assert_eq!(takable.updates.len(), 1);
+        let err_content = take(&mut takable);
+        assert!(err_content.is_err());
+        assert_eq!(content.len(), 1);
+        assert_eq!(takable.content.len(), 0);
+        assert_eq!(takable.updates.len(), 1);
+        takable.add_value(25, false);
+        assert_eq!(takable.content.len(), 0);
+        assert_eq!(takable.updates.len(), 2);
+        merge(&mut takable, content).unwrap();
+        assert_eq!(takable.content.len(), 3);
+        assert_eq!(takable.updates.len(), 0);
+
+        let err = merge(&mut takable, vec![]);
+        assert!(err.is_err());
+    }
 }

--- a/stake_vote/src/vote.rs
+++ b/stake_vote/src/vote.rs
@@ -1,13 +1,22 @@
+use crate::utils::TakableContent;
+use crate::utils::TakableMap;
 use crate::AccountPretty;
 use crate::Slot;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
+use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::vote::state::VoteState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub type VoteMap = HashMap<Pubkey, Arc<StoredVote>>;
+
+impl TakableContent<StoredVote> for VoteMap {
+    fn add_value(&mut self, val: StoredVote) {
+        VoteStore::vote_map_insert_vote(self, val.pubkey, val);
+    }
+}
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct StoredVote {
@@ -19,17 +28,13 @@ pub struct StoredVote {
 
 #[derive(Default)]
 pub struct VoteStore {
-    votes: VoteMap,
-    updates: Vec<(Pubkey, StoredVote)>,
-    extracted: bool,
+    votes: TakableMap<StoredVote, VoteMap>,
 }
 
 impl VoteStore {
     pub fn new(capacity: usize) -> Self {
         VoteStore {
-            votes: HashMap::with_capacity(capacity),
-            updates: vec![],
-            extracted: false,
+            votes: TakableMap::new(HashMap::with_capacity(capacity)),
         }
     }
     pub fn add_vote(
@@ -53,32 +58,99 @@ impl VoteStore {
                 write_version: new_account.write_version,
             };
 
-            //during extract push the new update or
-            //don't insertnow account change that has been done in next epoch.
-            //put in update pool to be merged next epoch change.
-            let insert_stake =
-                !self.extracted || new_voteacc.last_update_slot > current_end_epoch_slot;
-            match insert_stake {
-                false => self.updates.push((new_account.pubkey, new_voteacc)),
-                true => self.insert_vote(new_account.pubkey, new_voteacc),
-            }
+            let action_update_slot = new_voteacc.last_update_slot;
+            self.votes
+                .add_value(new_voteacc, action_update_slot <= current_end_epoch_slot);
         }
 
         Ok(())
     }
+    //helper method to extract and merge stakes.
+    pub fn take_votestore(votestore: &mut VoteStore) -> anyhow::Result<VoteMap> {
+        crate::utils::take(&mut votestore.votes)
+    }
+
+    pub fn merge_votestore(votestore: &mut VoteStore, vote_map: VoteMap) -> anyhow::Result<()> {
+        crate::utils::merge(&mut votestore.votes, vote_map)
+    }
+
     fn insert_vote(&mut self, vote_account: Pubkey, vote_data: StoredVote) {
-        todo!();
+        Self::vote_map_insert_vote(&mut self.votes.content, vote_account, vote_data);
     }
 
     fn remove_from_store(&mut self, account_pk: &Pubkey, update_slot: Slot) {
         if self
             .votes
+            .content
             .get(account_pk)
             .map(|vote| vote.last_update_slot <= update_slot)
             .unwrap_or(true)
         {
             log::info!("Vote remove_from_store for {}", account_pk.to_string());
-            self.votes.remove(account_pk);
+            self.votes.content.remove(account_pk);
         }
     }
+
+    fn vote_map_insert_vote(map: &mut VoteMap, vote_account_pk: Pubkey, vote_data: StoredVote) {
+        match map.entry(vote_account_pk) {
+            std::collections::hash_map::Entry::Occupied(occupied) => {
+                let voteacc = occupied.into_mut(); // <-- get mut reference to existing value
+                if voteacc.last_update_slot <= vote_data.last_update_slot {
+                    // generate a lot of trace log::trace!(
+                    //     "Vote updated for: {vote_account_pk} node_id:{} root_slot:{:?}",
+                    //     vote_data.vote_data.node_pubkey,
+                    //     vote_data.vote_data.root_slot,
+                    // );
+                    if vote_data.vote_data.root_slot.is_none() {
+                        log::info!("Update vote account:{vote_account_pk} with None root slot.");
+                    }
+
+                    if voteacc.vote_data.root_slot.is_none() {
+                        log::info!(
+                            "Update vote account:{vote_account_pk} that were having None root slot."
+                        );
+                    }
+
+                    *voteacc = Arc::new(vote_data);
+                }
+            }
+            // If value doesn't exist yet, then insert a new value of 1
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                log::info!(
+                    "New Vote added for: {vote_account_pk} node_id:{}, root slot:{:?}",
+                    vote_data.vote_data.node_pubkey,
+                    vote_data.vote_data.root_slot,
+                );
+                vacant.insert(Arc::new(vote_data));
+            }
+        };
+    }
+}
+
+pub fn merge_program_account_in_vote_map(
+    vote_map: &mut VoteMap,
+    pa_list: Vec<(Pubkey, Account)>,
+    last_update_slot: Slot,
+) {
+    pa_list
+        .into_iter()
+        .filter_map(
+            |(pk, account)| match VoteState::deserialize(&account.data) {
+                Ok(vote) => Some((pk, vote)),
+                Err(err) => {
+                    log::warn!("Error during vote account data deserialisation:{err}");
+                    None
+                }
+            },
+        )
+        .for_each(|(pk, vote)| {
+            //log::info!("Vote init {pk} :{vote:?}");
+            let vote = StoredVote {
+                pubkey: pk,
+                vote_data: vote,
+                last_update_slot,
+                write_version: 0,
+            };
+            VoteStore::vote_map_insert_vote(vote_map, pk, vote);
+        });
 }


### PR DESCRIPTION
This PR add the leader calculus to the #229 one.
The leader calculus is done at the end of the epoch on the stake and vote account stored and updated during the epoch.
It is done in a separate task, so I use that specific container call TakableMap that allow to take the content but allow caching update that arrive during the calculus and apply then when the content return (merge).
This process: Take, calculate in a task, merge is done using a simple state machine using LeaderScheduleEvent.
