### PR TITLE
Stakes and votes management: add stake and schedule bootstrap

### DIFF
--- a/core/src/structures/leaderschedule.rs
+++ b/core/src/structures/leaderschedule.rs
@@ -16,7 +16,7 @@ impl CalculatedSchedule {
         commitment: Option<CommitmentConfig>,
         data_cache: &DataCache,
     ) -> Option<HashMap<String, Vec<usize>>> {
-        let commitment = commitment.unwrap_or_else(|| CommitmentConfig::confirmed());
+        let commitment = commitment.unwrap_or_else(CommitmentConfig::confirmed);
         let slot = match slot {
             Some(slot) => slot,
             None => {

--- a/stake_vote/src/account.rs
+++ b/stake_vote/src/account.rs
@@ -57,7 +57,7 @@ impl AccountPretty {
     }
 
     pub fn read_stake(&self) -> anyhow::Result<Option<Delegation>> {
-        read_stake_from_account_data(&mut self.data.as_slice())
+        read_stake_from_account_data(self.data.as_slice())
     }
 
     pub fn read_vote(&self) -> anyhow::Result<VoteState> {
@@ -74,9 +74,7 @@ impl std::fmt::Display for AccountPretty {
         write!(
             f,
             "{} at slot:{} lpt:{}",
-            self.pubkey.to_string(),
-            self.slot,
-            self.lamports
+            self.pubkey, self.slot, self.lamports
         )
     }
 }

--- a/stake_vote/src/bootstrap.rs
+++ b/stake_vote/src/bootstrap.rs
@@ -28,7 +28,7 @@ pub async fn bootstrap_scheduleepoch_data(data_cache: &DataCache) -> ScheduleEpo
         .new_warmup_cooldown_rate_epoch(data_cache.epoch_data.get_epoch_schedule());
 
     let bootstrap_epoch = crate::utils::get_current_epoch(data_cache).await;
-    let current_schedule_epoch = ScheduleEpochData {
+    ScheduleEpochData {
         current_epoch: bootstrap_epoch.epoch,
         slots_in_epoch: bootstrap_epoch.slots_in_epoch,
         last_slot_in_epoch: data_cache
@@ -36,9 +36,7 @@ pub async fn bootstrap_scheduleepoch_data(data_cache: &DataCache) -> ScheduleEpo
             .get_last_slot_in_epoch(bootstrap_epoch.epoch),
         current_confirmed_slot: bootstrap_epoch.absolute_slot,
         new_rate_activation_epoch,
-    };
-
-    current_schedule_epoch
+    }
 }
 
 /*
@@ -111,6 +109,7 @@ pub enum BootstrapEvent {
     Exit,
 }
 
+#[allow(clippy::large_enum_variant)] //214 byte large and only use during bootstrap.
 enum BootsrapProcessResult {
     TaskHandle(JoinHandle<BootstrapEvent>),
     Event(BootstrapEvent),
@@ -225,6 +224,7 @@ fn process_bootstrap_event(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn bootstrap_accounts(
     rpc_url: String,
 ) -> Result<(Vec<(Pubkey, Account)>, Vec<(Pubkey, Account)>, Account), ClientError> {

--- a/stake_vote/src/bootstrap.rs
+++ b/stake_vote/src/bootstrap.rs
@@ -1,13 +1,29 @@
 use crate::epoch::ScheduleEpochData;
+use crate::stake::StakeMap;
+use crate::stake::StakeStore;
+use crate::vote::VoteMap;
+use crate::vote::VoteStore;
+use anyhow::bail;
+use futures_util::stream::FuturesUnordered;
+use solana_client::client_error::ClientError;
+use solana_client::rpc_client::RpcClient;
 use solana_lite_rpc_core::stores::data_cache::DataCache;
 use solana_lite_rpc_core::structures::leaderschedule::CalculatedSchedule;
-use solana_rpc_client::nonblocking::rpc_client::RpcClient;
-use std::sync::Arc;
+use solana_lite_rpc_core::structures::leaderschedule::LeaderScheduleData;
+use solana_sdk::account::Account;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::stake_history::StakeHistory;
+use std::time::Duration;
+use tokio::task::JoinHandle;
 
-pub async fn bootstrap_process_data(
-    data_cache: &DataCache,
-    rpc_client: Arc<RpcClient>,
-) -> (ScheduleEpochData, BootstrapData) {
+//File where the Vote and stake use to calculate the leader schedule at epoch are stored.
+//Use to bootstrap current and next epoch leader schedule.
+//TODO to be removed with inter RPC bootstrap and snapshot read.
+pub const CURRENT_EPOCH_VOTE_STAKES_FILE: &str = "current_vote_stakes.json";
+pub const NEXT_EPOCH_VOTE_STAKES_FILE: &str = "next_vote_stakes.json";
+
+pub async fn bootstrap_scheduleepoch_data(data_cache: &DataCache) -> ScheduleEpochData {
     let new_rate_activation_epoch = solana_sdk::feature_set::FeatureSet::default()
         .new_warmup_cooldown_rate_epoch(data_cache.epoch_data.get_epoch_schedule());
 
@@ -22,25 +38,269 @@ pub async fn bootstrap_process_data(
         new_rate_activation_epoch,
     };
 
-    //Init bootstrap process
-    let bootstrap_data = crate::bootstrap::BootstrapData {
-        done: false,
-        sleep_time: 1,
-        rpc_client,
-    };
-    (current_schedule_epoch, bootstrap_data)
+    current_schedule_epoch
 }
 
-pub fn bootstrap_leader_schedule(
-    current_file_patch: &str,
-    next_file_patch: &str,
+/*
+Bootstrap state changes
+
+  InitBootstrap
+       |
+  |Fetch accounts|
+
+    |          |
+  Error   BootstrapAccountsFetched(account list)
+    |          |
+ |Exit|     |Extract stores|
+               |         |
+            Error     StoreExtracted(account list, stores)
+               |                       |
+            | Wait(1s)|           |Merge accounts in store|
+               |                            |          |
+   BootstrapAccountsFetched(account list)  Error    AccountsMerged(stores)
+                                            |                        |
+                                      |Log and skip|          |Merges store|
+                                      |Account     |            |         |
+                                                               Error     End
+                                                                |
+                                                              |never occurs restart|
+                                                                 |
+                                                          InitBootstrap
+*/
+
+pub fn run_bootstrap_events(
+    event: BootstrapEvent,
+    bootstrap_tasks: &mut FuturesUnordered<JoinHandle<BootstrapEvent>>,
+    stakestore: &mut StakeStore,
+    votestore: &mut VoteStore,
+) -> anyhow::Result<Option<bool>> {
+    let result = process_bootstrap_event(event, stakestore, votestore);
+    match result {
+        BootsrapProcessResult::TaskHandle(jh) => {
+            bootstrap_tasks.push(jh);
+            Ok(None)
+        }
+        BootsrapProcessResult::Event(event) => {
+            run_bootstrap_events(event, bootstrap_tasks, stakestore, votestore)
+        }
+        BootsrapProcessResult::End => Ok(Some(true)),
+        BootsrapProcessResult::Error(err) => bail!(err),
+    }
+}
+
+pub enum BootstrapEvent {
+    InitBootstrap {
+        sleep_time: u64,
+        rpc_url: String,
+    },
+    BootstrapAccountsFetched(
+        Vec<(Pubkey, Account)>,
+        Vec<(Pubkey, Account)>,
+        Account,
+        String,
+    ),
+    StoreExtracted(
+        StakeMap,
+        VoteMap,
+        Vec<(Pubkey, Account)>,
+        Vec<(Pubkey, Account)>,
+        Account,
+        String,
+    ),
+    AccountsMerged(StakeMap, Option<StakeHistory>, VoteMap, String),
+    Exit,
+}
+
+enum BootsrapProcessResult {
+    TaskHandle(JoinHandle<BootstrapEvent>),
+    Event(BootstrapEvent),
+    Error(String),
+    End,
+}
+
+fn process_bootstrap_event(
+    event: BootstrapEvent,
+    stakestore: &mut StakeStore,
+    votestore: &mut VoteStore,
+) -> BootsrapProcessResult {
+    match event {
+        BootstrapEvent::InitBootstrap {
+            sleep_time,
+            rpc_url,
+        } => {
+            let jh = tokio::task::spawn_blocking(move || {
+                log::info!("BootstrapEvent::InitBootstrap RECV");
+                if sleep_time > 0 {
+                    std::thread::sleep(Duration::from_secs(sleep_time));
+                }
+                match crate::bootstrap::bootstrap_accounts(rpc_url.clone()) {
+                    Ok((stakes, votes, history)) => {
+                        BootstrapEvent::BootstrapAccountsFetched(stakes, votes, history, rpc_url)
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "Bootstrap account error during fetching accounts err:{err}. Exit"
+                        );
+                        BootstrapEvent::Exit
+                    }
+                }
+            });
+            BootsrapProcessResult::TaskHandle(jh)
+        }
+        BootstrapEvent::BootstrapAccountsFetched(stakes, votes, history, rpc_url) => {
+            log::info!("BootstrapEvent::BootstrapAccountsFetched RECV");
+            match (
+                StakeStore::take_stakestore(stakestore),
+                VoteStore::take_votestore(votestore),
+            ) {
+                (Ok((stake_map, _)), Ok(vote_map)) => {
+                    BootsrapProcessResult::Event(BootstrapEvent::StoreExtracted(
+                        stake_map, vote_map, stakes, votes, history, rpc_url,
+                    ))
+                }
+                _ => {
+                    let jh = tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        BootstrapEvent::BootstrapAccountsFetched(stakes, votes, history, rpc_url)
+                    });
+                    BootsrapProcessResult::TaskHandle(jh)
+                }
+            }
+        }
+        BootstrapEvent::StoreExtracted(
+            mut stake_map,
+            mut vote_map,
+            stakes,
+            votes,
+            history,
+            rpc_url,
+        ) => {
+            log::info!("BootstrapEvent::StoreExtracted RECV");
+
+            let stake_history = crate::account::read_historystake_from_account(history);
+            if stake_history.is_none() {
+                return BootsrapProcessResult::Error(
+                    "Bootstrap error, can't read stake history from account data.".to_string(),
+                );
+            }
+
+            //merge new PA with stake map and vote map in a specific task
+            let jh = tokio::task::spawn_blocking({
+                move || {
+                    //update pa_list to set slot update to start epoq one.
+                    crate::stake::merge_program_account_in_strake_map(
+                        &mut stake_map,
+                        stakes,
+                        0, //with RPC no way to know the slot of the account update. Set to 0.
+                    );
+                    crate::vote::merge_program_account_in_vote_map(
+                        &mut vote_map,
+                        votes,
+                        0, //with RPC no way to know the slot of the account update. Set to 0.
+                    );
+
+                    BootstrapEvent::AccountsMerged(stake_map, stake_history, vote_map, rpc_url)
+                }
+            });
+            BootsrapProcessResult::TaskHandle(jh)
+        }
+        BootstrapEvent::AccountsMerged(stake_map, stake_history, vote_map, rpc_url) => {
+            log::info!("BootstrapEvent::AccountsMerged RECV");
+            match (
+                StakeStore::merge_stakestore(stakestore, stake_map, stake_history),
+                VoteStore::merge_votestore(votestore, vote_map),
+            ) {
+                (Ok(()), Ok(())) => BootsrapProcessResult::End,
+                _ => {
+                    //TODO remove this error using type state
+                    log::warn!("BootstrapEvent::AccountsMerged merge stake or vote fail,  non extracted stake/vote map err, restart bootstrap");
+                    BootsrapProcessResult::Event(BootstrapEvent::InitBootstrap {
+                        sleep_time: 10,
+                        rpc_url,
+                    })
+                }
+            }
+        }
+        BootstrapEvent::Exit => panic!("Bootstrap account can't be done exit"),
+    }
+}
+
+fn bootstrap_accounts(
+    rpc_url: String,
+) -> Result<(Vec<(Pubkey, Account)>, Vec<(Pubkey, Account)>, Account), ClientError> {
+    get_stake_account(rpc_url)
+        .and_then(|(stakes, rpc_url)| {
+            get_vote_account(rpc_url).map(|(votes, rpc_url)| (stakes, votes, rpc_url))
+        })
+        .and_then(|(stakes, votes, rpc_url)| {
+            get_stakehistory_account(rpc_url).map(|history| (stakes, votes, history))
+        })
+}
+
+fn get_stake_account(rpc_url: String) -> Result<(Vec<(Pubkey, Account)>, String), ClientError> {
+    log::info!("TaskToExec RpcGetStakeAccount start");
+    let rpc_client = RpcClient::new_with_timeout_and_commitment(
+        rpc_url.clone(),
+        Duration::from_secs(600),
+        CommitmentConfig::finalized(),
+    );
+    let res_stake = rpc_client.get_program_accounts(&solana_sdk::stake::program::id());
+    log::info!("TaskToExec RpcGetStakeAccount END");
+    res_stake.map(|stake| (stake, rpc_url))
+}
+
+fn get_vote_account(rpc_url: String) -> Result<(Vec<(Pubkey, Account)>, String), ClientError> {
+    log::info!("TaskToExec RpcGetVoteAccount start");
+    let rpc_client = RpcClient::new_with_timeout_and_commitment(
+        rpc_url.clone(),
+        Duration::from_secs(600),
+        CommitmentConfig::finalized(),
+    );
+    let res_vote = rpc_client.get_program_accounts(&solana_sdk::vote::program::id());
+    log::info!("TaskToExec RpcGetVoteAccount END");
+    res_vote.map(|votes| (votes, rpc_url))
+}
+
+pub fn get_stakehistory_account(rpc_url: String) -> Result<Account, ClientError> {
+    log::info!("TaskToExec RpcGetStakeHistory start");
+    let rpc_client = RpcClient::new_with_timeout_and_commitment(
+        rpc_url,
+        Duration::from_secs(600),
+        CommitmentConfig::finalized(),
+    );
+    let res_stake = rpc_client.get_account(&solana_sdk::sysvar::stake_history::id());
+    log::info!("TaskToExec RpcGetStakeHistory END",);
+    res_stake
+}
+
+pub fn bootstrap_current_leader_schedule(
     slots_in_epoch: u64,
 ) -> anyhow::Result<CalculatedSchedule> {
-    todo!();
-}
+    let (current_epoch, current_stakes) =
+        crate::utils::read_schedule_vote_stakes(CURRENT_EPOCH_VOTE_STAKES_FILE)?;
+    let (next_epoch, next_stakes) =
+        crate::utils::read_schedule_vote_stakes(NEXT_EPOCH_VOTE_STAKES_FILE)?;
 
-pub struct BootstrapData {
-    pub done: bool,
-    pub sleep_time: u64,
-    pub rpc_client: Arc<RpcClient>,
+    //calcualte leader schedule for all vote stakes.
+    let current_schedule = crate::leader_schedule::calculate_leader_schedule(
+        &current_stakes,
+        current_epoch,
+        slots_in_epoch,
+    );
+    let next_schedule =
+        crate::leader_schedule::calculate_leader_schedule(&next_stakes, next_epoch, slots_in_epoch);
+
+    Ok(CalculatedSchedule {
+        current: Some(LeaderScheduleData {
+            schedule: current_schedule,
+            //TODO use epoch stake for get_vote_accounts
+            epoch: current_epoch,
+        }),
+        next: Some(LeaderScheduleData {
+            schedule: next_schedule,
+            //TODO use epoch stake for get_vote_accounts
+            //            vote_stakes: next_stakes.stake_vote_map,
+            epoch: next_epoch,
+        }),
+    })
 }

--- a/stake_vote/src/epoch.rs
+++ b/stake_vote/src/epoch.rs
@@ -47,7 +47,7 @@ impl ScheduleEpochData {
             Some(crate::leader_schedule::LeaderScheduleEvent::Init(
                 self.current_epoch,
                 self.slots_in_epoch,
-                self.new_rate_activation_epoch.clone(),
+                self.new_rate_activation_epoch,
             ))
         } else {
             None

--- a/stake_vote/src/leader_schedule.rs
+++ b/stake_vote/src/leader_schedule.rs
@@ -46,6 +46,7 @@ InitLeaderscedule        MergeStore(stakes, votes, schedule)
                       InitLeaderscedule
 */
 
+#[allow(clippy::large_enum_variant)] //256 byte large and only use during schedule calculus.
 pub enum LeaderScheduleEvent {
     Init(u64, u64, Option<solana_sdk::clock::Epoch>),
     MergeStoreAndSaveSchedule(

--- a/stake_vote/src/stake.rs
+++ b/stake_vote/src/stake.rs
@@ -65,9 +65,9 @@ impl StakeStore {
         }
     }
 
-    pub fn get_stake_history(&self) -> Option<StakeHistory> {
-        self.stakes.content.1.clone()
-    }
+    // pub fn get_stake_history(&self) -> Option<StakeHistory> {
+    //     self.stakes.content.1.clone()
+    // }
 
     pub fn notify_stake_change(
         &mut self,

--- a/stake_vote/src/utils.rs
+++ b/stake_vote/src/utils.rs
@@ -34,6 +34,7 @@ struct StringSavedStake {
     stake_vote_map: HashMap<String, (u64, Arc<StoredVote>)>,
 }
 
+#[allow(clippy::type_complexity)]
 pub fn read_schedule_vote_stakes(
     file_path: &str,
 ) -> anyhow::Result<(u64, HashMap<Pubkey, (u64, Arc<StoredVote>)>)> {

--- a/stake_vote/src/vote.rs
+++ b/stake_vote/src/vote.rs
@@ -74,10 +74,6 @@ impl VoteStore {
         crate::utils::merge(&mut votestore.votes, vote_map)
     }
 
-    fn insert_vote(&mut self, vote_account: Pubkey, vote_data: StoredVote) {
-        Self::vote_map_insert_vote(&mut self.votes.content, vote_account, vote_data);
-    }
-
     fn remove_from_store(&mut self, account_pk: &Pubkey, update_slot: Slot) {
         if self
             .votes

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -78,3 +78,13 @@ test('get epoch info', async () => {
 
 });
 
+
+test('get leader schedule', async () => {
+    {
+        const leaderSchedule = await connection.getLeaderSchedule();
+        expect(Object.keys(leaderSchedule).length > 0);        
+    }
+});
+
+
+


### PR DESCRIPTION
Add stake and vote account bootstrap from the RPC getProgramAccount.
Add leader schedule, save at epoch change and reload at start if present.