### PR TITLE
Bootstrap leader schedule from rpc

### DIFF
--- a/cluster-endpoints/src/grpc_leaders_getter.rs
+++ b/cluster-endpoints/src/grpc_leaders_getter.rs
@@ -44,15 +44,26 @@ impl LeaderFetcherInterface for GrpcLeaderGetter {
             .current
             .as_ref()
             .map(|e| e.epoch)
-            .unwrap_or(to_epoch);
+            .unwrap_or(to_epoch)
+            + 1;
         if from > to {
-            bail!("invalid arguments for get_slot_leaders");
+            bail!(
+                "invalid arguments for get_slot_leaders: from:{from} to:{to} from:{from} > to:{to}"
+            );
         }
         if from_epoch < current_epoch || from_epoch > next_epoch {
-            bail!("invalid arguments for get_slot_leaders");
+            bail!(
+                "invalid arguments for get_slot_leaders: from:{from} to:{to} \
+             from_epoch:{from_epoch} < current_epoch:{current_epoch} \
+             || from_epoch > next_epoch:{next_epoch}"
+            );
         }
         if to_epoch < current_epoch || to_epoch > next_epoch {
-            bail!("invalid arguments for get_slot_leaders");
+            bail!(
+                "invalid arguments for get_slot_leaders: from:{from} to:{to} \
+             to_epoch:{to_epoch} < current_epoch:{current_epoch} \
+                || to_epoch:{to_epoch} > next_epoch:{next_epoch}"
+            );
         }
 
         let limit = to - from;

--- a/core/src/structures/epoch.rs
+++ b/core/src/structures/epoch.rs
@@ -60,7 +60,9 @@ impl EpochCache {
         self.epoch_schedule.get_last_slot_in_epoch(epoch)
     }
 
-    pub async fn bootstrap_epoch(rpc_client: &RpcClient) -> anyhow::Result<EpochCache> {
+    pub async fn bootstrap_epoch(
+        rpc_client: &RpcClient,
+    ) -> anyhow::Result<(EpochCache, EpochInfo)> {
         let res_epoch = rpc_client
             .get_account(&solana_sdk::sysvar::epoch_schedule::id())
             .await?;
@@ -72,9 +74,14 @@ impl EpochCache {
             bail!("Error during bootstrap epoch. SysvarAccountType::EpochSchedule can't be deserilized. Epoch can't be calculated.");
         };
 
-        Ok(EpochCache {
-            epoch_schedule: Arc::new(epoch_schedule),
-        })
+        let epoch_info = rpc_client.get_epoch_info().await?;
+
+        Ok((
+            EpochCache {
+                epoch_schedule: Arc::new(epoch_schedule),
+            },
+            epoch_info,
+        ))
     }
 }
 

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -246,7 +246,7 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
             )
         } else {
             (
-                Arc::new(JsonRpcLeaderGetter::new(rpc_client.clone(), 40, 12)),
+                Arc::new(JsonRpcLeaderGetter::new(rpc_client.clone(), 1024, 128)),
                 None,
             )
         };

--- a/stake_vote/src/epoch.rs
+++ b/stake_vote/src/epoch.rs
@@ -56,7 +56,7 @@ impl ScheduleEpochData {
         &mut self,
         history: StakeHistory,
     ) -> Option<LeaderScheduleEvent> {
-        log::info!("set_epoch_stake_history");
+        log::debug!("set_epoch_stake_history");
         self.new_stake_history = Some(history);
         self.verify_epoch_change()
     }
@@ -68,7 +68,7 @@ impl ScheduleEpochData {
         //to avoid to delay too much the schedule, start the calculus at the end of the epoch.
         //the first epoch slot arrive very late cause of the stake account notification from the validator.
         if self.current_confirmed_slot >= self.last_slot_in_epoch {
-            log::info!(
+            log::debug!(
                 "manage_change_epoch at slot:{} last_slot_in_epoch:{}",
                 self.current_confirmed_slot,
                 self.last_slot_in_epoch

--- a/stake_vote/src/leader_schedule.rs
+++ b/stake_vote/src/leader_schedule.rs
@@ -117,7 +117,7 @@ fn process_leadershedule_event(
         ) => {
             match (&mut stakestore.stakes, &mut votestore.votes).take() {
                 TakeResult::Map((stake_map, (vote_map, mut epoch_cache))) => {
-                    log::info!("LeaderScheduleEvent::CalculateScedule");
+                    log::info!("Start calculate leader schedule");
                     //do the calculus in a blocking task.
                     let jh = tokio::task::spawn_blocking({
                         move || {
@@ -221,7 +221,6 @@ fn process_leadershedule_event(
             (new_epoch, slots_in_epoch, epoch_schedule),
             stake_history,
         ) => {
-            log::info!("LeaderScheduleEvent::MergeStoreAndSaveSchedule RECV");
             match (
                 stakestore.stakes.merge(stake_map),
                 votestore.votes.merge((vote_map, epoch_cache)),
@@ -304,7 +303,7 @@ pub fn calculate_leader_schedule(
     let mut seed = [0u8; 32];
     seed[0..8].copy_from_slice(&epoch.to_le_bytes());
     sort_stakes(&mut stakes);
-    log::info!("calculate_leader_schedule stakes:{stakes:?} epoch:{epoch}");
+    //log::info!("calculate_leader_schedule stakes:{stakes:?} epoch:{epoch}");
     LeaderSchedule::new(&stakes, seed, slots_in_epoch, NUM_CONSECUTIVE_LEADER_SLOTS)
 }
 

--- a/stake_vote/src/leader_schedule.rs
+++ b/stake_vote/src/leader_schedule.rs
@@ -13,7 +13,9 @@ use solana_lite_rpc_core::structures::leaderschedule::LeaderScheduleData;
 use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::stake_history::StakeHistory;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
@@ -305,6 +307,20 @@ pub fn calculate_leader_schedule(
     sort_stakes(&mut stakes);
     //log::info!("calculate_leader_schedule stakes:{stakes:?} epoch:{epoch}");
     LeaderSchedule::new(&stakes, seed, slots_in_epoch, NUM_CONSECUTIVE_LEADER_SLOTS)
+}
+
+pub fn calculate_slot_leaders_from_schedule(
+    leader_scheudle: &HashMap<String, Vec<usize>>,
+) -> Result<Vec<Pubkey>, String> {
+    let mut slot_leaders_map = BTreeMap::new();
+    for (pk, index_list) in leader_scheudle {
+        for index in index_list {
+            let pubkey = Pubkey::from_str(pk)
+                .map_err(|err| format!("Pubkey from leader schedule not a plublic key:{err}"))?;
+            slot_leaders_map.insert(index, pubkey);
+        }
+    }
+    Ok(slot_leaders_map.into_values().collect())
 }
 
 // Cribbed from leader_schedule_utils

--- a/stake_vote/src/vote.rs
+++ b/stake_vote/src/vote.rs
@@ -36,10 +36,8 @@ impl EpochVoteStakesCache {
     }
 
     pub fn add_stakes_for_epoch(&mut self, vote_stakes: EpochVoteStakes) {
-        log::info!("add_stakes_for_epoch :{}", vote_stakes.epoch);
-        if self.cache.insert(vote_stakes.epoch, vote_stakes).is_some() {
-            log::warn!("Override existing vote stake epoch cache for epoch:");
-        }
+        log::debug!("add_stakes_for_epoch :{}", vote_stakes.epoch);
+        self.cache.insert(vote_stakes.epoch, vote_stakes);
     }
 }
 


### PR DESCRIPTION
Add leader schedule bootstrap from RPC at start if the bootstrap file is missing or with the wrong epoch from the current one. This process is done before the bootstrap process of the stake_vote module to avoid to wait stake and vote account fetching.

LiteRPC now start in geyser leader schedule config without the bootstrap file.
 
Tested on Testnet JP os3 server during more than one epoch.
