### PR TITLE
remove block_debug_listen

### DIFF
--- a/cluster-endpoints/src/grpc_inspect.rs
+++ b/cluster-endpoints/src/grpc_inspect.rs
@@ -1,4 +1,4 @@
-use log::{debug, warn};
+use log::{debug, error, warn};
 use solana_lite_rpc_core::types::BlockStream;
 use solana_sdk::commitment_config::CommitmentConfig;
 use tokio::sync::broadcast::error::RecvError;
@@ -56,7 +56,7 @@ pub fn block_debug_listen(
                     );
                 }
                 Err(other_err) => {
-                    panic!("Error receiving block: {:?}", other_err);
+                    error!("Error receiving block: {:?}", other_err);
                 }
             }
 

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -380,15 +380,6 @@ pub fn create_grpc_subscription(
     let (block_multiplex_channel, jh_multiplex_blockstream) =
         create_grpc_multiplex_blocks_subscription(grpc_sources);
 
-    grpc_inspect::block_debug_listen(
-        block_multiplex_channel.resubscribe(),
-        CommitmentConfig::confirmed(),
-    );
-    grpc_inspect::block_debug_listen(
-        block_multiplex_channel.resubscribe(),
-        CommitmentConfig::finalized(),
-    );
-
     let cluster_info_polling =
         poll_vote_accounts_and_cluster_info(rpc_client, cluster_info_sx, va_sx);
 

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -2,7 +2,7 @@ use crate::grpc_multiplex::{
     create_grpc_multiplex_blocks_subscription, create_grpc_multiplex_slots_subscription,
 };
 use crate::{
-    endpoint_stremers::EndpointStreaming, grpc_inspect,
+    endpoint_stremers::EndpointStreaming,
     rpc_polling::vote_accounts_and_cluster_info_polling::poll_vote_accounts_and_cluster_info,
 };
 use anyhow::Context;


### PR DESCRIPTION
caused a panic - need more time to investigate

2024-01-17T20:31:42.913 app[683d392fd45368] ams [info] thread 'tokio-runtime-worker' panicked at cluster-endpoints/src/grpc_inspect.rs:59:21: 2024-01-17T20:31:42.913 app[683d392fd45368] ams [info] Error receiving block: Closed 2024-01-17T20:31:42.922 app[683d392fd45368] ams [info] 2024-01-17T20:31:42.912597Z ERROR lite_rpc: Services quit unexpectedly Err(cluster endpoint failure (Err(JoinError::Panic(Id(20), ...)), 1, [JoinHandle { id: Id(19) }, JoinHandle { id: Id(23) }])