### PR TITLE
implement simple binary that dumps the effective config

### DIFF
--- a/lite-rpc/Cargo.toml
+++ b/lite-rpc/Cargo.toml
@@ -9,6 +9,14 @@ repository = "https://github.com/blockworks-foundation/lite-rpc"
 license = "AGPL"
 publish = false
 
+[[bin]]
+name = "lite-rpc"
+path = "src/main.rs"
+
+[[bin]]
+name = "lite-rpc-dumpconfig"
+path = "src/dumpconfig-tool.rs"
+
 [dependencies]
 solana-sdk = { workspace = true }
 solana-rpc-client = { workspace = true }

--- a/lite-rpc/src/dumpconfig-tool.rs
+++ b/lite-rpc/src/dumpconfig-tool.rs
@@ -1,0 +1,15 @@
+use log::info;
+use lite_rpc::cli::Config;
+
+#[tokio::main]
+pub async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let config = Config::load().await?;
+
+    // CAUTION: the output might contain credentials
+    println!("Lite RPC effective config: \n{:?}", config);
+
+    info!("Lite RPC effective config: {:?}", config);
+
+    Ok(())
+}


### PR DESCRIPTION
Dump the Config effectively used for Lite RPC.
Config became quite cumbersome with ENV+config.json+defaults.

> RUST_LOG=info cargo run --bin lite-rpc-dumpconfig

output is provided on `stdout` and `info logger`