### PR TITLE
fix bug causing endless geyser restart loops

### DIFF
--- a/cluster-endpoints/src/grpc_multiplex.rs
+++ b/cluster-endpoints/src/grpc_multiplex.rs
@@ -175,6 +175,7 @@ pub fn create_grpc_multiplex_blocks_subscription(
             );
 
             // by blockhash
+            // this map consumes sigificant amount of memory constrainted by CLEANUP_SLOTS_BEHIND_FINALIZED
             let mut recent_processed_blocks = HashMap::<String, ProducedBlock>::new();
             // both streams support backpressure, see log:
             // grpc_subscription_autoreconnect_tasks: downstream receiver did not pick put message for 500ms - keep waiting

--- a/cluster-endpoints/src/grpc_multiplex.rs
+++ b/cluster-endpoints/src/grpc_multiplex.rs
@@ -162,8 +162,12 @@ pub fn create_grpc_multiplex_blocks_subscription(
                 );
             }
 
+            // tasks which should be cleaned up uppon reconnect
+            let mut task_list: Vec<AbortHandle> = vec![];
+
             let processed_blocks_tasks =
                 create_grpc_multiplex_processed_block_stream(&grpc_sources, processed_block_sender);
+            task_list.extend(processed_blocks_tasks);
 
             let confirmed_blockmeta_stream = create_grpc_multiplex_block_meta_stream(
                 &grpc_sources,
@@ -270,7 +274,7 @@ pub fn create_grpc_multiplex_blocks_subscription(
                     }
                 }
             } // -- END receiver loop
-            processed_blocks_tasks.iter().for_each(|task| task.abort());
+            task_list.iter().for_each(|task| task.abort());
         } // -- END reconnect loop
     });
 


### PR DESCRIPTION
Issue was introduced with https://github.com/blockworks-foundation/lite-rpc/pull/299 merge commit.

**fix:** reset the error counter `cleanup_without_recv_full_blocks` to zero when block arrives
