### PR TITLE
CI: pin chargo-chef version for MSRV=1.73

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 FROM rust:1.73.0 as base
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef@0.1.62 --locked
 RUN rustup component add rustfmt
 RUN apt-get update && apt-get install -y clang cmake ssh
 WORKDIR /app


### PR DESCRIPTION


```
#11 5.734   Downloaded autocfg v1.1.0
#11 5.760 error: failed to compile `cargo-chef v0.1.63`, intermediate artifacts can be found at `/tmp/cargo-installzonn1h`.
#11 5.760 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
#11 5.760 
#11 5.760 Caused by:
#11 5.760   package `clap v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0
#11 ERROR: executor failed running [/bin/sh -c cargo install cargo-chef --locked]: exit code: 101

#7 [run 1/4] FROM docker.io/library/debian:bookworm-slim@sha256:7802002798b0e351323ed2357ae6dc5a8c4d0a05a57e7f4d8f97136151d3d603
```

[example of broken CI](https://github.com/blockworks-foundation/lite-rpc/actions/runs/7870656050/job/21473630366)