### PR TITLE
wrap producedblock struct and avoid cloning it

### DIFF
--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -65,7 +65,6 @@ impl PostgresBlock {
             slot: self.slot as Slot,
             parent_slot: self.parent_slot as Slot,
             block_time: self.block_time as u64,
-            // commitment_config,
             previous_blockhash: self.previous_blockhash.clone(),
             rewards: rewards_vec,
         };

--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -2,7 +2,7 @@ use super::postgres_epoch::PostgresEpoch;
 use super::postgres_session::PostgresSession;
 use log::{debug, warn};
 use solana_lite_rpc_core::structures::epoch::EpochRef;
-use solana_lite_rpc_core::structures::produced_block::TransactionInfo;
+use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{encoding::BASE64, structures::produced_block::ProducedBlock};
 use solana_sdk::clock::Slot;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -56,7 +56,7 @@ impl PostgresBlock {
             .map(|x| BASE64.deserialize::<Vec<Reward>>(x).ok())
             .unwrap_or(None);
 
-        ProducedBlock {
+        let inner = ProducedBlockInner {
             // TODO implement
             transactions: transaction_infos,
             leader_id: None,
@@ -65,10 +65,11 @@ impl PostgresBlock {
             slot: self.slot as Slot,
             parent_slot: self.parent_slot as Slot,
             block_time: self.block_time as u64,
-            commitment_config,
+            // commitment_config,
             previous_blockhash: self.previous_blockhash.clone(),
             rewards: rewards_vec,
-        }
+        };
+        ProducedBlock::new(inner, commitment_config)
     }
 }
 

--- a/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
@@ -316,7 +316,7 @@ fn div_ceil(a: usize, b: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_lite_rpc_core::structures::produced_block::TransactionInfo;
+    use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
     use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::signature::Signature;
     use std::str::FromStr;
@@ -364,7 +364,7 @@ mod tests {
         let sig1 = Signature::from_str("5VBroA4MxsbZdZmaSEb618WRRwhWYW9weKhh3md1asGRx7nXDVFLua9c98voeiWdBE7A9isEoLL7buKyaVRSK1pV").unwrap();
         let sig2 = Signature::from_str("3d9x3rkVQEoza37MLJqXyadeTbEJGUB6unywK4pjeRLJc16wPsgw3dxPryRWw3UaLcRyuxEp1AXKGECvroYxAEf2").unwrap();
 
-        ProducedBlock {
+        let inner = ProducedBlockInner {
             block_height: 42,
             blockhash: "blockhash".to_string(),
             previous_blockhash: "previous_blockhash".to_string(),
@@ -373,10 +373,11 @@ mod tests {
             transactions: vec![create_test_tx(sig1), create_test_tx(sig2)],
             // TODO double if this is unix millis or seconds
             block_time: 1699260872000,
-            commitment_config: CommitmentConfig::finalized(),
+            // commitment_config: CommitmentConfig::finalized(),
             leader_id: None,
             rewards: None,
-        }
+        };
+        ProducedBlock::new(inner, CommitmentConfig::finalized())
     }
 
     fn create_test_tx(signature: Signature) -> TransactionInfo {

--- a/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
@@ -373,7 +373,6 @@ mod tests {
             transactions: vec![create_test_tx(sig1), create_test_tx(sig2)],
             // TODO double if this is unix millis or seconds
             block_time: 1699260872000,
-            // commitment_config: CommitmentConfig::finalized(),
             leader_id: None,
             rewards: None,
         };

--- a/blockstore/tests/blockstore_integration_tests.rs
+++ b/blockstore/tests/blockstore_integration_tests.rs
@@ -296,15 +296,11 @@ fn spawn_client_to_blockstorage(
         // note: no startup deloy
         loop {
             match blocks_notifier.recv().await {
-                Ok(ProducedBlock {
-                    slot,
-                    commitment_config,
-                    ..
-                }) => {
-                    if commitment_config != CommitmentConfig::confirmed() {
+                Ok(produced_block) => {
+                    if produced_block.commitment_config != CommitmentConfig::confirmed() {
                         continue;
                     }
-                    let confirmed_slot = slot;
+                    let confirmed_slot = produced_block.slot;
                     // we cannot expect the most recent data
                     let query_slot = confirmed_slot - 3;
                     match block_storage_query.query_block(query_slot).await {

--- a/blockstore/tests/multiple_strategy_block_store_tests.rs
+++ b/blockstore/tests/multiple_strategy_block_store_tests.rs
@@ -18,7 +18,6 @@ pub fn create_test_block(slot: u64, commitment_config: CommitmentConfig) -> Prod
         parent_slot: slot - 1,
         transactions: vec![],
         block_time: 0,
-        // commitment_config,
         leader_id: None,
         slot,
         rewards: Some(vec![Reward {

--- a/blockstore/tests/multiple_strategy_block_store_tests.rs
+++ b/blockstore/tests/multiple_strategy_block_store_tests.rs
@@ -4,21 +4,21 @@ use solana_lite_rpc_blockstore::block_stores::postgres::postgres_block_store_que
 use solana_lite_rpc_blockstore::block_stores::postgres::postgres_block_store_writer::PostgresBlockStore;
 use solana_lite_rpc_blockstore::block_stores::postgres::PostgresSessionConfig;
 use solana_lite_rpc_core::structures::epoch::EpochCache;
-use solana_lite_rpc_core::structures::produced_block::ProducedBlock;
+use solana_lite_rpc_core::structures::produced_block::{ProducedBlock, ProducedBlockInner};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::reward_type::RewardType;
 use solana_sdk::{commitment_config::CommitmentConfig, hash::Hash};
 use solana_transaction_status::Reward;
 
 pub fn create_test_block(slot: u64, commitment_config: CommitmentConfig) -> ProducedBlock {
-    ProducedBlock {
+    let inner = ProducedBlockInner {
         block_height: slot,
         blockhash: Hash::new_unique().to_string(),
         previous_blockhash: Hash::new_unique().to_string(),
         parent_slot: slot - 1,
         transactions: vec![],
         block_time: 0,
-        commitment_config,
+        // commitment_config,
         leader_id: None,
         slot,
         rewards: Some(vec![Reward {
@@ -28,7 +28,8 @@ pub fn create_test_block(slot: u64, commitment_config: CommitmentConfig) -> Prod
             reward_type: Some(RewardType::Voting),
             commission: None,
         }]),
-    }
+    };
+    ProducedBlock::new(inner, commitment_config)
 }
 
 #[ignore = "need postgres database"]

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -264,7 +264,6 @@ pub fn from_grpc_block_update(
         block_time: block.block_time.map(|time| time.timestamp).unwrap() as u64,
         blockhash: block.blockhash,
         previous_blockhash: block.parent_blockhash,
-        // commitment_config,
         leader_id,
         parent_slot: block.parent_slot,
         slot: block.slot,

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -35,6 +35,7 @@ use tracing::debug_span;
 use crate::rpc_polling::vote_accounts_and_cluster_info_polling::{
     poll_cluster_info, poll_vote_accounts,
 };
+use solana_lite_rpc_core::structures::produced_block::ProducedBlockInner;
 use yellowstone_grpc_proto::prelude::SubscribeUpdateBlock;
 
 /// grpc version of ProducedBlock mapping
@@ -254,7 +255,7 @@ pub fn from_grpc_block_update(
         None
     };
 
-    ProducedBlock {
+    let inner = ProducedBlockInner {
         transactions: txs,
         block_height: block
             .block_height
@@ -263,12 +264,13 @@ pub fn from_grpc_block_update(
         block_time: block.block_time.map(|time| time.timestamp).unwrap() as u64,
         blockhash: block.blockhash,
         previous_blockhash: block.parent_blockhash,
-        commitment_config,
+        // commitment_config,
         leader_id,
         parent_slot: block.parent_slot,
         slot: block.slot,
         rewards,
-    }
+    };
+    ProducedBlock::new(inner, commitment_config)
 }
 
 pub fn create_grpc_subscription(

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_lite_rpc_core::encoding::BinaryEncoding;
-use solana_lite_rpc_core::structures::produced_block::TransactionInfo;
+use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{
     structures::{
         produced_block::ProducedBlock,
@@ -319,7 +319,7 @@ pub fn from_ui_block(
 
     let block_time = block.block_time.unwrap_or(0) as u64;
 
-    ProducedBlock {
+    let inner = ProducedBlockInner {
         transactions: txs,
         block_height,
         leader_id,
@@ -328,9 +328,10 @@ pub fn from_ui_block(
         parent_slot,
         block_time,
         slot,
-        commitment_config,
+        // commitment_config,
         rewards,
-    }
+    };
+    ProducedBlock::new(inner, commitment_config)
 }
 
 #[inline]

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -328,7 +328,6 @@ pub fn from_ui_block(
         parent_slot,
         block_time,
         slot,
-        // commitment_config,
         rewards,
     };
     ProducedBlock::new(inner, commitment_config)

--- a/core/src/structures/produced_block.rs
+++ b/core/src/structures/produced_block.rs
@@ -23,7 +23,7 @@ pub struct TransactionInfo {
 
 #[derive(Debug, Clone)]
 pub struct ProducedBlock {
-    // TODO check/document why Arc is needed here
+    // Arc is required for channels
     inner: Arc<ProducedBlockInner>,
     pub commitment_config: CommitmentConfig,
 }
@@ -61,19 +61,19 @@ pub struct ProducedBlockInner {
 }
 
 impl ProducedBlock {
-    /// moving commitment level to finalized
-    pub fn to_finalized_block(&self) -> Self {
-        ProducedBlock {
-            inner: self.inner.clone(),
-            commitment_config: CommitmentConfig::finalized(),
-        }
-    }
-
     /// moving commitment level to confirmed
     pub fn to_confirmed_block(&self) -> Self {
         ProducedBlock {
             inner: self.inner.clone(),
             commitment_config: CommitmentConfig::confirmed(),
+        }
+    }
+
+    /// moving commitment level to finalized
+    pub fn to_finalized_block(&self) -> Self {
+        ProducedBlock {
+            inner: self.inner.clone(),
+            commitment_config: CommitmentConfig::finalized(),
         }
     }
 }

--- a/services/src/data_caching_service.rs
+++ b/services/src/data_caching_service.rs
@@ -64,7 +64,7 @@ impl DataCachingService {
                     _ => TransactionConfirmationStatus::Processed,
                 };
 
-                for tx in block.transactions {
+                for tx in &block.transactions {
                     let block_info = data_cache
                         .block_information_store
                         .get_block_info(&tx.recent_blockhash);
@@ -101,7 +101,7 @@ impl DataCachingService {
                     // notify
                     data_cache
                         .tx_subs
-                        .notify(block.slot, &tx, block.commitment_config)
+                        .notify(block.slot, tx, block.commitment_config)
                         .await;
                 }
             }


### PR DESCRIPTION

* separates confirmation_config from block data
* put data on heap and use `Arc`
* implement Debug trait

> ProducedBlock { slot: 254169151, commitment_config: processed, blockhash: BULfZwLswkDbHhTrHGDASUtmNAG8gk6TV2njnobjYLyd, transactions_count: 806 }