### PR TITLE
from grpc block ProduceBlock mapping - Performance+Typing

### DIFF
--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -190,10 +190,10 @@ impl PostgresBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solana_sdk::hash::Hash;
     use solana_sdk::message::{v0, MessageHeader, VersionedMessage};
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
-    use solana_sdk::hash::Hash;
 
     #[test]
     fn map_postgresblock_to_produced_block() {

--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -1,6 +1,7 @@
 use super::postgres_epoch::PostgresEpoch;
 use super::postgres_session::PostgresSession;
 use log::{debug, warn};
+use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::epoch::EpochRef;
 use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{encoding::BASE64, structures::produced_block::ProducedBlock};
@@ -31,12 +32,12 @@ impl From<&ProducedBlock> for PostgresBlock {
             .unwrap_or(None);
 
         Self {
-            blockhash: value.blockhash.clone(),
+            blockhash: value.blockhash.to_string(),
             block_height: value.block_height as i64,
             slot: value.slot as i64,
             parent_slot: value.parent_slot as i64,
             block_time: value.block_time as i64,
-            previous_blockhash: value.previous_blockhash.clone(),
+            previous_blockhash: value.previous_blockhash.to_string(),
             // TODO add leader_id, etc.
             rewards,
             leader_id: value.leader_id.clone(),
@@ -60,12 +61,12 @@ impl PostgresBlock {
             // TODO implement
             transactions: transaction_infos,
             leader_id: None,
-            blockhash: self.blockhash.clone(),
+            blockhash: hash_from_str(&self.blockhash).expect("valid blockhash"),
             block_height: self.block_height as u64,
             slot: self.slot as Slot,
             parent_slot: self.parent_slot as Slot,
             block_time: self.block_time as u64,
-            previous_blockhash: self.previous_blockhash.clone(),
+            previous_blockhash: hash_from_str(&self.previous_blockhash).expect("valid blockhash"),
             rewards: rewards_vec,
         };
         ProducedBlock::new(inner, commitment_config)
@@ -221,7 +222,7 @@ mod tests {
             cu_requested: None,
             prioritization_fees: None,
             cu_consumed: None,
-            recent_blockhash: "recent_blockhash".to_string(),
+            recent_blockhash: solana_sdk::hash::Hash::new_unique(),
             message: "message".to_string(),
             writable_accounts: vec![],
             readable_accounts: vec![],

--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -189,7 +189,7 @@ impl PostgresBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::commitment_config::CommitmentConfig;
+    use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
 
     #[test]
     fn map_postgresblock_to_produced_block() {
@@ -215,7 +215,7 @@ mod tests {
 
     fn create_tx_info() -> TransactionInfo {
         TransactionInfo {
-            signature: "signature".to_string(),
+            signature: Signature::new_unique(),
             is_vote: false,
             err: None,
             cu_requested: None,

--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -193,16 +193,17 @@ mod tests {
     use solana_sdk::message::{v0, MessageHeader, VersionedMessage};
     use solana_sdk::pubkey::Pubkey;
     use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
+    use solana_sdk::hash::Hash;
 
     #[test]
     fn map_postgresblock_to_produced_block() {
         let block = PostgresBlock {
             slot: 5050505,
-            blockhash: "blockhash".to_string(),
+            blockhash: Hash::new_unique().to_string(),
             block_height: 4040404,
             parent_slot: 5050500,
             block_time: 12121212,
-            previous_blockhash: "previous_blockhash".to_string(),
+            previous_blockhash: Hash::new_unique().to_string(),
             rewards: None,
             leader_id: None,
         };

--- a/blockstore/src/block_stores/postgres/postgres_block.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block.rs
@@ -190,6 +190,8 @@ impl PostgresBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solana_sdk::message::{v0, MessageHeader, VersionedMessage};
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::{commitment_config::CommitmentConfig, signature::Signature};
 
     #[test]
@@ -223,10 +225,21 @@ mod tests {
             prioritization_fees: None,
             cu_consumed: None,
             recent_blockhash: solana_sdk::hash::Hash::new_unique(),
-            message: "message".to_string(),
+            message: create_test_message(),
             writable_accounts: vec![],
             readable_accounts: vec![],
             address_lookup_tables: vec![],
         }
+    }
+
+    fn create_test_message() -> VersionedMessage {
+        VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                ..MessageHeader::default()
+            },
+            account_keys: vec![Pubkey::new_unique()],
+            ..v0::Message::default()
+        })
     }
 }

--- a/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
@@ -366,8 +366,8 @@ mod tests {
 
         let inner = ProducedBlockInner {
             block_height: 42,
-            blockhash: "blockhash".to_string(),
-            previous_blockhash: "previous_blockhash".to_string(),
+            blockhash: solana_sdk::hash::Hash::new_unique(),
+            previous_blockhash: solana_sdk::hash::Hash::new_unique(),
             parent_slot: 666,
             slot: 223555999,
             transactions: vec![create_test_tx(sig1), create_test_tx(sig2)],
@@ -387,7 +387,7 @@ mod tests {
             cu_requested: Some(40000),
             prioritization_fees: Some(5000),
             cu_consumed: Some(32000),
-            recent_blockhash: "recent_blockhash".to_string(),
+            recent_blockhash: solana_sdk::hash::Hash::new_unique(),
             message: "some message".to_string(),
             writable_accounts: vec![],
             readable_accounts: vec![],

--- a/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
@@ -318,6 +318,8 @@ mod tests {
     use super::*;
     use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
     use solana_sdk::commitment_config::CommitmentConfig;
+    use solana_sdk::message::{v0, MessageHeader, VersionedMessage};
+    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::signature::Signature;
     use std::str::FromStr;
 
@@ -388,10 +390,21 @@ mod tests {
             prioritization_fees: Some(5000),
             cu_consumed: Some(32000),
             recent_blockhash: solana_sdk::hash::Hash::new_unique(),
-            message: "some message".to_string(),
+            message: create_test_message(),
             writable_accounts: vec![],
             readable_accounts: vec![],
             address_lookup_tables: vec![],
         }
+    }
+
+    fn create_test_message() -> VersionedMessage {
+        VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                ..MessageHeader::default()
+            },
+            account_keys: vec![Pubkey::new_unique()],
+            ..v0::Message::default()
+        })
     }
 }

--- a/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
+++ b/blockstore/src/block_stores/postgres/postgres_block_store_writer.rs
@@ -381,7 +381,7 @@ mod tests {
 
     fn create_test_tx(signature: Signature) -> TransactionInfo {
         TransactionInfo {
-            signature: signature.to_string(),
+            signature,
             is_vote: false,
             err: None,
             cu_requested: Some(40000),

--- a/blockstore/src/block_stores/postgres/postgres_transaction.rs
+++ b/blockstore/src/block_stores/postgres/postgres_transaction.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use futures_util::pin_mut;
 use log::debug;
+use solana_lite_rpc_core::encoding::BinaryEncoding;
 use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::epoch::EpochRef;
 use solana_lite_rpc_core::{encoding::BASE64, structures::produced_block::TransactionInfo};
@@ -42,7 +43,7 @@ impl PostgresTransaction {
             prioritization_fees: value.prioritization_fees.map(|x| x as i64),
             cu_consumed: value.cu_consumed.map(|x| x as i64),
             recent_blockhash: value.recent_blockhash.to_string(),
-            message: value.message.clone(),
+            message: BinaryEncoding::Base64.encode(value.message.serialize()),
             slot: slot as i64,
         }
     }
@@ -58,7 +59,9 @@ impl PostgresTransaction {
             prioritization_fees: self.prioritization_fees.map(|x| x as u64),
             cu_consumed: self.cu_consumed.map(|x| x as u64),
             recent_blockhash: hash_from_str(&self.recent_blockhash).expect("valid blockhash"),
-            message: self.message.clone(),
+            message: BinaryEncoding::Base64
+                .deserialize(&self.message)
+                .expect("serialized message"),
             // TODO readable_accounts etc.
             readable_accounts: vec![],
             writable_accounts: vec![],

--- a/blockstore/src/block_stores/postgres/postgres_transaction.rs
+++ b/blockstore/src/block_stores/postgres/postgres_transaction.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use futures_util::pin_mut;
 use log::debug;
+use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::epoch::EpochRef;
 use solana_lite_rpc_core::{encoding::BASE64, structures::produced_block::TransactionInfo};
 use solana_sdk::signature::Signature;
@@ -40,7 +41,7 @@ impl PostgresTransaction {
             cu_requested: value.cu_requested.map(|x| x as i64),
             prioritization_fees: value.prioritization_fees.map(|x| x as i64),
             cu_consumed: value.cu_consumed.map(|x| x as i64),
-            recent_blockhash: value.recent_blockhash.clone(),
+            recent_blockhash: value.recent_blockhash.to_string(),
             message: value.message.clone(),
             slot: slot as i64,
         }
@@ -56,7 +57,7 @@ impl PostgresTransaction {
             cu_requested: self.cu_requested.map(|x| x as u32),
             prioritization_fees: self.prioritization_fees.map(|x| x as u64),
             cu_consumed: self.cu_consumed.map(|x| x as u64),
-            recent_blockhash: self.recent_blockhash.clone(),
+            recent_blockhash: hash_from_str(&self.recent_blockhash).expect("valid blockhash"),
             message: self.message.clone(),
             // TODO readable_accounts etc.
             readable_accounts: vec![],

--- a/blockstore/src/block_stores/postgres/postgres_transaction.rs
+++ b/blockstore/src/block_stores/postgres/postgres_transaction.rs
@@ -1,7 +1,10 @@
+use std::str::FromStr;
+
 use futures_util::pin_mut;
 use log::debug;
 use solana_lite_rpc_core::structures::epoch::EpochRef;
 use solana_lite_rpc_core::{encoding::BASE64, structures::produced_block::TransactionInfo};
+use solana_sdk::signature::Signature;
 use solana_sdk::slot_history::Slot;
 use solana_sdk::transaction::TransactionError;
 use tokio::time::Instant;
@@ -28,7 +31,7 @@ pub struct PostgresTransaction {
 impl PostgresTransaction {
     pub fn new(value: &TransactionInfo, slot: Slot) -> Self {
         Self {
-            signature: value.signature.clone(),
+            signature: value.signature.to_string(),
             err: value
                 .err
                 .clone()
@@ -45,7 +48,7 @@ impl PostgresTransaction {
 
     pub fn to_transaction_info(&self) -> TransactionInfo {
         TransactionInfo {
-            signature: self.signature.clone(),
+            signature: Signature::from_str(self.signature.as_str()).unwrap(),
             err: self
                 .err
                 .as_ref()

--- a/blockstore/tests/multiple_strategy_block_store_tests.rs
+++ b/blockstore/tests/multiple_strategy_block_store_tests.rs
@@ -13,8 +13,8 @@ use solana_transaction_status::Reward;
 pub fn create_test_block(slot: u64, commitment_config: CommitmentConfig) -> ProducedBlock {
     let inner = ProducedBlockInner {
         block_height: slot,
-        blockhash: Hash::new_unique().to_string(),
-        previous_blockhash: Hash::new_unique().to_string(),
+        blockhash: Hash::new_unique(),
+        previous_blockhash: Hash::new_unique(),
         parent_slot: slot - 1,
         transactions: vec![],
         block_time: 0,

--- a/cluster-endpoints/src/grpc_inspect.rs
+++ b/cluster-endpoints/src/grpc_inspect.rs
@@ -3,6 +3,7 @@ use log::{debug, info, warn};
 use solana_lite_rpc_core::types::BlockStream;
 use solana_sdk::clock::Slot;
 use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::hash::Hash;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -236,7 +237,7 @@ pub fn debugtask_blockstream_slot_progression(
     let last_slot_seen = latest_slot_seen_shared.clone();
     tokio::spawn(async move {
         let mut last_highest_slot_number = 0;
-        let mut last_blockhash: Option<String> = None;
+        let mut last_blockhash: Option<Hash> = None;
 
         'recv_loop: loop {
             match block_notifier.recv().await {
@@ -290,7 +291,7 @@ pub fn debugtask_blockstream_slot_progression(
                                 block.slot, block.blockhash, block.previous_blockhash, last_blockhash);
                         }
                     }
-                    last_blockhash = Some(block.blockhash.to_string());
+                    last_blockhash = Some(block.blockhash);
                 } // -- Ok
                 Err(RecvError::Lagged(missed_blocks)) => {
                     // very unlikely to happen

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -35,6 +35,7 @@ use tracing::debug_span;
 use crate::rpc_polling::vote_accounts_and_cluster_info_polling::{
     poll_cluster_info, poll_vote_accounts,
 };
+use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::produced_block::ProducedBlockInner;
 use yellowstone_grpc_proto::prelude::SubscribeUpdateBlock;
 
@@ -202,7 +203,7 @@ pub fn from_grpc_block_update(
                 cu_requested,
                 prioritization_fees,
                 cu_consumed: compute_units_consumed,
-                recent_blockhash: message.recent_blockhash().to_string(),
+                recent_blockhash: *message.recent_blockhash(),
                 message: BASE64.encode(message.serialize()),
                 readable_accounts,
                 writable_accounts,
@@ -249,8 +250,8 @@ pub fn from_grpc_block_update(
             .map(|block_height| block_height.block_height)
             .unwrap(),
         block_time: block.block_time.map(|time| time.timestamp).unwrap() as u64,
-        blockhash: block.blockhash,
-        previous_blockhash: block.parent_blockhash,
+        blockhash: hash_from_str(&block.blockhash).expect("valid blockhash"),
+        previous_blockhash: hash_from_str(&block.parent_blockhash).expect("valid blockhash"),
         leader_id,
         parent_slot: block.parent_slot,
         slot: block.slot,

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -196,7 +196,7 @@ pub fn from_grpc_block_update(
                 .unwrap_or_default();
 
             Some(TransactionInfo {
-                signature: signature.to_string(),
+                signature,
                 is_vote: is_vote_transaction,
                 err,
                 cu_requested,

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_lite_rpc_core::structures::account_filter::AccountFilters;
 use solana_lite_rpc_core::{
-    encoding::BASE64,
     structures::produced_block::{ProducedBlock, TransactionInfo},
     AnyhowJoinHandle,
 };
@@ -204,7 +203,7 @@ pub fn from_grpc_block_update(
                 prioritization_fees,
                 cu_consumed: compute_units_consumed,
                 recent_blockhash: *message.recent_blockhash(),
-                message: BASE64.encode(message.serialize()),
+                message,
                 readable_accounts,
                 writable_accounts,
                 address_lookup_tables,

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -209,7 +209,7 @@ pub fn from_ui_block(
                 return None;
             };
 
-            let signature = tx.signatures[0].to_string();
+            let signature = tx.signatures[0];
             let cu_consumed = match compute_units_consumed {
                 OptionSerializer::Some(cu_consumed) => Some(cu_consumed),
                 _ => None,

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_lite_rpc_core::encoding::BinaryEncoding;
 use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{
@@ -266,7 +265,6 @@ pub fn from_ui_block(
             };
 
             let blockhash = tx.message.recent_blockhash();
-            let message = BinaryEncoding::Base64.encode(tx.message.serialize());
 
             let is_vote_transaction = tx.message.instructions().iter().any(|i| {
                 i.program_id(tx.message.static_account_keys())
@@ -301,7 +299,7 @@ pub fn from_ui_block(
                 prioritization_fees,
                 cu_consumed,
                 recent_blockhash: *blockhash,
-                message,
+                message: tx.message,
                 readable_accounts,
                 writable_accounts,
                 address_lookup_tables,

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_lite_rpc_core::encoding::BinaryEncoding;
+use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{
     structures::{
@@ -184,8 +185,8 @@ pub fn from_ui_block(
     let block_height = block.block_height.unwrap_or_default();
     let txs = block.transactions.unwrap_or_default();
 
-    let blockhash = block.blockhash;
-    let previous_blockhash = block.previous_blockhash;
+    let blockhash = hash_from_str(&block.blockhash).expect("valid blockhash");
+    let previous_blockhash = hash_from_str(&block.previous_blockhash).expect("valid blockhash");
     let parent_slot = block.parent_slot;
     let rewards = block.rewards.clone();
 
@@ -264,7 +265,7 @@ pub fn from_ui_block(
                 }
             };
 
-            let blockhash = tx.message.recent_blockhash().to_string();
+            let blockhash = tx.message.recent_blockhash();
             let message = BinaryEncoding::Base64.encode(tx.message.serialize());
 
             let is_vote_transaction = tx.message.instructions().iter().any(|i| {
@@ -299,7 +300,7 @@ pub fn from_ui_block(
                 cu_requested,
                 prioritization_fees,
                 cu_consumed,
-                recent_blockhash: blockhash,
+                recent_blockhash: *blockhash,
                 message,
                 readable_accounts,
                 writable_accounts,

--- a/core/src/stores/data_cache.rs
+++ b/core/src/stores/data_cache.rs
@@ -75,7 +75,7 @@ impl DataCache {
         Self {
             block_information_store: BlockInformationStore::new(BlockInformation {
                 block_height: 0,
-                blockhash: Hash::new_unique().to_string(),
+                blockhash: Hash::new_unique(),
                 cleanup_slot: 1000,
                 commitment_config: CommitmentConfig::finalized(),
                 last_valid_blockheight: 300,

--- a/core/src/structures/notifications.rs
+++ b/core/src/structures/notifications.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Utc};
+use solana_sdk::signature::Signature;
 use solana_sdk::{commitment_config::CommitmentLevel, transaction::TransactionError};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 #[derive(Debug)]
 pub struct TransactionNotification {
-    pub signature: String,                   // 88 bytes
+    pub signature: Signature,                // 88 bytes
     pub recent_slot: u64,                    // 8 bytes
     pub forwarded_slot: u64,                 // 8 bytes
     pub forwarded_local_time: DateTime<Utc>, // 8 bytes

--- a/core/src/structures/produced_block.rs
+++ b/core/src/structures/produced_block.rs
@@ -1,4 +1,5 @@
 use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::hash::Hash;
 use solana_sdk::message::v0::MessageAddressTableLookup;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -16,7 +17,7 @@ pub struct TransactionInfo {
     pub cu_requested: Option<u32>,
     pub prioritization_fees: Option<u64>,
     pub cu_consumed: Option<u64>,
-    pub recent_blockhash: String,
+    pub recent_blockhash: Hash,
     pub message: String,
     pub writable_accounts: Vec<Pubkey>,
     pub readable_accounts: Vec<Pubkey>,
@@ -61,12 +62,12 @@ impl Deref for ProducedBlock {
 pub struct ProducedBlockInner {
     pub transactions: Vec<TransactionInfo>,
     pub leader_id: Option<String>,
-    pub blockhash: String,
+    pub blockhash: Hash,
     pub block_height: u64,
     pub slot: Slot,
     pub parent_slot: Slot,
     pub block_time: u64,
-    pub previous_blockhash: String,
+    pub previous_blockhash: Hash,
     pub rewards: Option<Vec<Reward>>,
 }
 

--- a/core/src/structures/produced_block.rs
+++ b/core/src/structures/produced_block.rs
@@ -1,6 +1,7 @@
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::message::v0::MessageAddressTableLookup;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
 use solana_sdk::{slot_history::Slot, transaction::TransactionError};
 use solana_transaction_status::Reward;
 use std::fmt::Debug;
@@ -9,7 +10,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TransactionInfo {
-    pub signature: String,
+    pub signature: Signature,
     pub is_vote: bool,
     pub err: Option<TransactionError>,
     pub cu_requested: Option<u32>,

--- a/core/src/structures/produced_block.rs
+++ b/core/src/structures/produced_block.rs
@@ -1,6 +1,7 @@
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
 use solana_sdk::message::v0::MessageAddressTableLookup;
+use solana_sdk::message::VersionedMessage;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 use solana_sdk::{slot_history::Slot, transaction::TransactionError};
@@ -18,7 +19,7 @@ pub struct TransactionInfo {
     pub prioritization_fees: Option<u64>,
     pub cu_consumed: Option<u64>,
     pub recent_blockhash: Hash,
-    pub message: String,
+    pub message: VersionedMessage,
     pub writable_accounts: Vec<Pubkey>,
     pub readable_accounts: Vec<Pubkey>,
     pub address_lookup_tables: Vec<MessageAddressTableLookup>,

--- a/core/src/structures/proxy_request_format.rs
+++ b/core/src/structures/proxy_request_format.rs
@@ -6,7 +6,6 @@ use solana_sdk::signature::Signature;
 use std::fmt;
 use std::fmt::Display;
 use std::net::SocketAddr;
-use std::str::FromStr;
 
 ///
 /// lite-rpc to proxy wire format
@@ -18,8 +17,8 @@ const FORMAT_VERSION1: u16 = 2500;
 pub struct TxData(Signature, Vec<u8>);
 
 impl TxData {
-    pub fn new(sig: String, tx_raw: Vec<u8>) -> Self {
-        TxData(Signature::from_str(sig.as_str()).unwrap(), tx_raw)
+    pub fn new(signature: Signature, tx_raw: Vec<u8>) -> Self {
+        TxData(signature, tx_raw)
     }
 }
 

--- a/core/src/structures/transaction_sent_info.rs
+++ b/core/src/structures/transaction_sent_info.rs
@@ -1,10 +1,11 @@
+use solana_sdk::signature::Signature;
 use solana_sdk::slot_history::Slot;
 
 pub type WireTransaction = Vec<u8>;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct SentTransactionInfo {
-    pub signature: String,
+    pub signature: Signature,
     pub slot: Slot,
     pub transaction: WireTransaction,
     pub last_valid_block_height: u64,

--- a/lite-rpc/src/bridge.rs
+++ b/lite-rpc/src/bridge.rs
@@ -25,6 +25,7 @@ use solana_rpc_client_api::{
     },
 };
 use solana_sdk::epoch_info::EpochInfo;
+use solana_sdk::signature::Signature;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, slot_history::Slot};
 use solana_transaction_status::{TransactionStatus, UiConfirmedBlock};
 
@@ -281,7 +282,8 @@ impl LiteRpcServer for LiteBridge {
 
         let sig_statuses = sigs
             .iter()
-            .map(|sig| self.data_cache.txs.get(sig).and_then(|v| v.status))
+            .map(|sig| Signature::from_str(sig).expect("signature must be valid"))
+            .map(|sig| self.data_cache.txs.get(&sig).and_then(|v| v.status))
             .collect();
 
         Ok(RpcResponse {

--- a/lite-rpc/src/bridge.rs
+++ b/lite-rpc/src/bridge.rs
@@ -30,6 +30,7 @@ use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, slot_histo
 use solana_transaction_status::{TransactionStatus, UiConfirmedBlock};
 
 use solana_lite_rpc_blockstore::history::History;
+use solana_lite_rpc_core::solana_utils::hash_from_str;
 use solana_lite_rpc_core::{
     encoding,
     stores::{block_information_store::BlockInformation, data_cache::DataCache},
@@ -211,7 +212,7 @@ impl LiteRpcServer for LiteBridge {
                 api_version: None,
             },
             value: RpcBlockhash {
-                blockhash,
+                blockhash: blockhash.to_string(),
                 last_valid_block_height: block_height + 150,
             },
         })
@@ -230,7 +231,10 @@ impl LiteRpcServer for LiteBridge {
         let (is_valid, slot) = self
             .data_cache
             .block_information_store
-            .is_blockhash_valid(&blockhash, commitment)
+            .is_blockhash_valid(
+                &hash_from_str(&blockhash).expect("valid blockhash"),
+                commitment,
+            )
             .await;
 
         Ok(RpcResponse {

--- a/lite-rpc/src/bridge_pubsub.rs
+++ b/lite-rpc/src/bridge_pubsub.rs
@@ -29,6 +29,7 @@ use solana_rpc_client_api::{
     response::{Response as RpcResponse, RpcKeyedAccount, RpcResponseContext, SlotInfo},
 };
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
 
 lazy_static::lazy_static! {
     static ref RPC_SIGNATURE_SUBSCRIBE: IntCounter =
@@ -136,7 +137,7 @@ impl LiteRpcPubSubServer for LitePubSubBridge {
     async fn signature_subscribe(
         &self,
         pending: PendingSubscriptionSink,
-        signature: String,
+        signature: Signature,
         config: RpcSignatureSubscribeConfig,
     ) -> SubscriptionResult {
         RPC_SIGNATURE_SUBSCRIBE.inc();

--- a/lite-rpc/src/postgres_logger/mod.rs
+++ b/lite-rpc/src/postgres_logger/mod.rs
@@ -53,7 +53,7 @@ impl SchemaSize for PostgresTx {
 impl From<&TransactionNotification> for PostgresTx {
     fn from(value: &TransactionNotification) -> Self {
         Self {
-            signature: value.signature.clone(),
+            signature: value.signature.to_string(),
             recent_slot: value.recent_slot as i64,
             forwarded_slot: value.forwarded_slot as i64,
             forwarded_local_time: value.forwarded_local_time,

--- a/lite-rpc/src/rpc_pubsub.rs
+++ b/lite-rpc/src/rpc_pubsub.rs
@@ -5,6 +5,7 @@ use solana_rpc_client_api::config::{
     RpcProgramAccountsConfig, RpcSignatureSubscribeConfig, RpcTransactionLogsConfig,
     RpcTransactionLogsFilter,
 };
+use solana_sdk::signature::Signature;
 
 pub type Result<T> = std::result::Result<T, jsonrpsee::core::Error>;
 
@@ -47,7 +48,7 @@ pub trait LiteRpcPubSub {
     #[subscription(name = "signatureSubscribe" => "signatureNotification", unsubscribe="signatureUnsubscribe", item=RpcResponse<serde_json::Value>)]
     async fn signature_subscribe(
         &self,
-        signature: String,
+        signature: Signature,
         config: RpcSignatureSubscribeConfig,
     ) -> SubscriptionResult;
 

--- a/quic-forward-proxy-integration-test/tests/quic_proxy_tpu_integrationtest.rs
+++ b/quic-forward-proxy-integration-test/tests/quic_proxy_tpu_integrationtest.rs
@@ -745,7 +745,7 @@ pub fn build_raw_sample_tx(i: u32) -> SentTransactionInfo {
         bincode::serialize::<VersionedTransaction>(&tx).expect("failed to serialize tx");
 
     SentTransactionInfo {
-        signature: tx.get_signature().to_string(),
+        signature: *tx.get_signature(),
         slot: 1,
         transaction,
         last_valid_block_height: 300,

--- a/services/src/data_caching_service.rs
+++ b/services/src/data_caching_service.rs
@@ -86,7 +86,7 @@ impl DataCachingService {
                     };
 
                     if data_cache.txs.update_status(
-                        &tx.signature,
+                        tx.signature,
                         TransactionStatus {
                             slot: block.slot,
                             confirmations: None,

--- a/services/src/transaction_service.rs
+++ b/services/src/transaction_service.rs
@@ -134,7 +134,7 @@ impl TransactionService {
 
         let max_replay = max_retries.map_or(self.max_retries, |x| x as usize);
         let transaction_info = SentTransactionInfo {
-            signature: signature.to_string(),
+            signature,
             last_valid_block_height: last_valid_blockheight,
             slot,
             transaction: raw_tx,

--- a/services/src/transaction_service.rs
+++ b/services/src/transaction_service.rs
@@ -127,7 +127,7 @@ impl TransactionService {
             ..
         }) = self
             .block_information_store
-            .get_block_info(&tx.get_recent_blockhash().to_string())
+            .get_block_info(tx.get_recent_blockhash())
         else {
             bail!("Blockhash not found in block store".to_string());
         };

--- a/services/src/tx_sender.rs
+++ b/services/src/tx_sender.rs
@@ -79,7 +79,7 @@ impl TxSender {
         for transaction_info in transaction_infos.iter() {
             trace!("sending transaction {}", transaction_info.signature);
             txs_sent.insert(
-                transaction_info.signature.clone(),
+                transaction_info.signature,
                 TxProps {
                     status: None,
                     last_valid_blockheight: transaction_info.last_valid_block_height,
@@ -105,7 +105,7 @@ impl TxSender {
                 .iter()
                 .enumerate()
                 .map(|(index, transaction_info)| TransactionNotification {
-                    signature: transaction_info.signature.clone(),
+                    signature: transaction_info.signature,
                     recent_slot: transaction_info.slot,
                     forwarded_slot,
                     forwarded_local_time,


### PR DESCRIPTION

- remove calls to Pubkey::default()
- use Signature for .signature instead of String
- use Hash for recent_blockhash instead of String
- refactor reading of compute_budget instructions
- move message serialization
