### PR TITLE
fix error log on service issue

### DIFF
--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -460,7 +460,7 @@ pub async fn main() -> anyhow::Result<()> {
         res = main => {
             // This should never happen
             log::error!("Services quit unexpectedly {res:?}");
-            bail!("")
+            bail!("Service quit unexpectedly {res:?}");
         }
         _ = ctrl_c_signal => {
             log::info!("Received ctrl+c signal");


### PR DESCRIPTION

Reproduction:
* run two lite-rpc processes

Stdout/stderr shows this
> Error: 


> 2024-03-15T11:13:43.087231Z ERROR lite_rpc: Services quit unexpectedly Err(Support Services Ok(Err(Prometheus exited unexpectedly: Ok(Err(Address already in use (os error 48))))))    
Error: 
