### PR TITLE
use geyser blockmeta to progress finalizedslot

### DIFF
--- a/accounts/src/account_service.rs
+++ b/accounts/src/account_service.rs
@@ -4,13 +4,13 @@ use anyhow::bail;
 use itertools::Itertools;
 use prometheus::{opts, register_int_gauge, IntGauge};
 use solana_account_decoder::{UiAccount, UiDataSliceConfig};
+use solana_lite_rpc_core::types::BlockInfoStream;
 use solana_lite_rpc_core::{
     commitment_utils::Commitment,
     structures::{
         account_data::{AccountData, AccountNotificationMessage, AccountStream},
         account_filter::AccountFilters,
     },
-    types::BlockStream,
     AnyhowJoinHandle,
 };
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
@@ -20,7 +20,6 @@ use solana_rpc_client_api::{
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, slot_history::Slot};
 use tokio::sync::broadcast::Sender;
-use solana_lite_rpc_core::types::BlockInfoStream;
 
 use crate::account_store_interface::AccountStorageInterface;
 

--- a/blockstore/tests/blockstore_integration_tests.rs
+++ b/blockstore/tests/blockstore_integration_tests.rs
@@ -70,7 +70,7 @@ async fn storage_test() {
     let (slot_notifier, _jh_multiplex_slotstream) =
         create_grpc_multiplex_processed_slots_subscription(grpc_sources.clone());
 
-    let (blocks_notifier, _jh_multiplex_blockstream) =
+    let (blocks_notifier, _blockmeta_output_stream, _jh_multiplex_blockstream) =
         create_grpc_multiplex_blocks_subscription(grpc_sources);
 
     let (epoch_cache, _) = EpochCache::bootstrap_epoch(&rpc_client).await.unwrap();

--- a/cluster-endpoints/src/endpoint_stremers.rs
+++ b/cluster-endpoints/src/endpoint_stremers.rs
@@ -1,11 +1,12 @@
 use solana_lite_rpc_core::{
     structures::account_data::AccountStream,
-    types::{BlockStream, ClusterInfoStream, SlotStream, VoteAccountStream},
+    types::{BlockStream, BlockInfoStream, ClusterInfoStream, SlotStream, VoteAccountStream},
 };
 
 /// subscribers to broadcast channels should assume that channels are not getting closed unless the system is shutting down
 pub struct EndpointStreaming {
     pub blocks_notifier: BlockStream,
+    pub blockinfo_notifier: BlockInfoStream,
     pub slot_notifier: SlotStream,
     pub vote_account_notifier: VoteAccountStream,
     pub cluster_info_notifier: ClusterInfoStream,

--- a/cluster-endpoints/src/endpoint_stremers.rs
+++ b/cluster-endpoints/src/endpoint_stremers.rs
@@ -1,6 +1,6 @@
 use solana_lite_rpc_core::{
     structures::account_data::AccountStream,
-    types::{BlockStream, BlockInfoStream, ClusterInfoStream, SlotStream, VoteAccountStream},
+    types::{BlockInfoStream, BlockStream, ClusterInfoStream, SlotStream, VoteAccountStream},
 };
 
 /// subscribers to broadcast channels should assume that channels are not getting closed unless the system is shutting down

--- a/cluster-endpoints/src/grpc_multiplex.rs
+++ b/cluster-endpoints/src/grpc_multiplex.rs
@@ -9,6 +9,7 @@ use solana_sdk::clock::Slot;
 use solana_sdk::commitment_config::CommitmentConfig;
 
 use solana_lite_rpc_core::solana_utils::hash_from_str;
+use solana_lite_rpc_core::structures::block_info::BlockInfo;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::time::Duration;
 use tokio::sync::broadcast::Receiver;
@@ -17,7 +18,6 @@ use tokio::time::{sleep, Instant};
 use tracing::debug_span;
 use yellowstone_grpc_proto::geyser::subscribe_update::UpdateOneof;
 use yellowstone_grpc_proto::geyser::SubscribeUpdate;
-use solana_lite_rpc_core::structures::block_info::BlockInfo;
 
 use crate::grpc_subscription::from_grpc_block_update;
 
@@ -198,7 +198,11 @@ fn create_grpc_multiplex_block_info_task(
 /// the channel must never be closed
 pub fn create_grpc_multiplex_blocks_subscription(
     grpc_sources: Vec<GrpcSourceConfig>,
-) -> (Receiver<ProducedBlock>, Receiver<BlockInfo>, AnyhowJoinHandle) {
+) -> (
+    Receiver<ProducedBlock>,
+    Receiver<BlockInfo>,
+    AnyhowJoinHandle,
+) {
     info!("Setup grpc multiplexed blocks connection...");
     if grpc_sources.is_empty() {
         info!("- no grpc connection configured");
@@ -394,7 +398,11 @@ pub fn create_grpc_multiplex_blocks_subscription(
         } // -- END reconnect loop
     });
 
-    (blocks_output_stream, blockinfo_output_stream, jh_block_emitter_task)
+    (
+        blocks_output_stream,
+        blockinfo_output_stream,
+        jh_block_emitter_task,
+    )
 }
 
 pub fn create_grpc_multiplex_processed_slots_subscription(

--- a/cluster-endpoints/src/grpc_multiplex.rs
+++ b/cluster-endpoints/src/grpc_multiplex.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Context};
 use geyser_grpc_connector::grpc_subscription_autoreconnect_tasks::create_geyser_autoconnection_task_with_mpsc;
-use geyser_grpc_connector::grpcmultiplex_fastestwins::FromYellowstoneExtractor;
 use geyser_grpc_connector::{GeyserFilter, GrpcSourceConfig, Message};
 use log::{debug, info, trace, warn};
 use solana_lite_rpc_core::structures::produced_block::ProducedBlock;
@@ -137,13 +136,18 @@ fn create_grpc_multiplex_block_meta_task(
                                     tip = proposed_slot;
                                     let block_meta = BlockInfo {
                                         slot: proposed_slot,
-                                        block_height: block_meta.block_height
-                                            .expect("block_height from geyser block meta").block_height,
+                                        block_height: block_meta
+                                            .block_height
+                                            .expect("block_height from geyser block meta")
+                                            .block_height,
                                         blockhash: hash_from_str(&block_meta.blockhash)
                                             .expect("valid blockhash"),
                                         commitment_config,
-                                        block_time: block_meta.block_time
-                                            .expect("block_time from geyser block meta").timestamp as u64
+                                        block_time: block_meta
+                                            .block_time
+                                            .expect("block_time from geyser block meta")
+                                            .timestamp
+                                            as u64,
                                     };
 
                                     let send_started_at = Instant::now();

--- a/cluster-endpoints/src/grpc_multiplex.rs
+++ b/cluster-endpoints/src/grpc_multiplex.rs
@@ -458,9 +458,6 @@ pub fn create_grpc_multiplex_processed_slots_subscription(
     (multiplexed_messages_rx, jh_multiplex_task)
 }
 
-struct BlockMetaExtractor(CommitmentConfig);
-
-
 fn map_slot_from_yellowstone_update(update: SubscribeUpdate) -> Option<Slot> {
     match update.update_oneof {
         Some(UpdateOneof::Slot(update_slot_message)) => Some(update_slot_message.slot),

--- a/cluster-endpoints/src/grpc_subscription.rs
+++ b/cluster-endpoints/src/grpc_subscription.rs
@@ -271,7 +271,7 @@ pub fn create_grpc_subscription(
     let (slot_multiplex_channel, jh_multiplex_slotstream) =
         create_grpc_multiplex_processed_slots_subscription(grpc_sources.clone());
 
-    let (block_multiplex_channel, jh_multiplex_blockstream) =
+    let (block_multiplex_channel, blockmeta_channel, jh_multiplex_blockstream) =
         create_grpc_multiplex_blocks_subscription(grpc_sources.clone());
 
     let cluster_info_polling = poll_cluster_info(rpc_client.clone(), cluster_info_sx);
@@ -283,6 +283,7 @@ pub fn create_grpc_subscription(
             create_grpc_account_streaming(grpc_sources, accounts_filter);
         let streamers = EndpointStreaming {
             blocks_notifier: block_multiplex_channel,
+            blockinfo_notifier: blockmeta_channel,
             slot_notifier: slot_multiplex_channel,
             cluster_info_notifier,
             vote_account_notifier,
@@ -300,6 +301,7 @@ pub fn create_grpc_subscription(
     } else {
         let streamers = EndpointStreaming {
             blocks_notifier: block_multiplex_channel,
+            blockinfo_notifier: blockmeta_channel,
             slot_notifier: slot_multiplex_channel,
             cluster_info_notifier,
             vote_account_notifier,

--- a/cluster-endpoints/src/json_rpc_subscription.rs
+++ b/cluster-endpoints/src/json_rpc_subscription.rs
@@ -16,6 +16,7 @@ pub fn create_json_rpc_polling_subscription(
 ) -> anyhow::Result<(EndpointStreaming, Vec<AnyhowJoinHandle>)> {
     let (slot_sx, slot_notifier) = tokio::sync::broadcast::channel(16);
     let (block_sx, blocks_notifier) = tokio::sync::broadcast::channel(16);
+    let (blockinfo_sx, blockinfo_notifier) = tokio::sync::broadcast::channel(16);
     let (cluster_info_sx, cluster_info_notifier) = tokio::sync::broadcast::channel(16);
     let (va_sx, vote_account_notifier) = tokio::sync::broadcast::channel(16);
     // does not support accounts support with rpc polling
@@ -26,6 +27,7 @@ pub fn create_json_rpc_polling_subscription(
     let mut block_polling_tasks = poll_block(
         rpc_client.clone(),
         block_sx,
+        blockinfo_sx,
         slot_notifier.resubscribe(),
         num_parallel_tasks,
     );
@@ -39,6 +41,7 @@ pub fn create_json_rpc_polling_subscription(
 
     let streamers = EndpointStreaming {
         blocks_notifier,
+        blockinfo_notifier,
         slot_notifier,
         cluster_info_notifier,
         vote_account_notifier,

--- a/cluster-endpoints/src/rpc_polling/poll_blocks.rs
+++ b/cluster-endpoints/src/rpc_polling/poll_blocks.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_lite_rpc_core::solana_utils::hash_from_str;
+use solana_lite_rpc_core::structures::block_info::BlockInfo;
 use solana_lite_rpc_core::structures::produced_block::{ProducedBlockInner, TransactionInfo};
 use solana_lite_rpc_core::{
     structures::{
@@ -26,7 +27,6 @@ use solana_transaction_status::{
 };
 use std::{sync::Arc, time::Duration};
 use tokio::sync::broadcast::{Receiver, Sender};
-use solana_lite_rpc_core::structures::block_info::BlockInfo;
 
 pub const NUM_PARALLEL_TASKS_DEFAULT: usize = 16;
 
@@ -339,15 +339,13 @@ pub fn from_ui_block(
     ProducedBlock::new(inner, commitment_config)
 }
 
-
 fn map_block_info(produced_block: &ProducedBlock) -> BlockInfo {
     BlockInfo {
         slot: produced_block.slot,
         block_height: produced_block.block_height,
         blockhash: produced_block.blockhash,
-        commitment_config: produced_block.commitment_config.clone(),
+        commitment_config: produced_block.commitment_config,
         block_time: produced_block.block_time,
-
     }
 }
 

--- a/core/src/stores/block_information_store.rs
+++ b/core/src/stores/block_information_store.rs
@@ -23,18 +23,6 @@ pub struct BlockInformation {
 }
 
 impl BlockInformation {
-    // TODO remove
-    pub fn from_block(block: &ProducedBlock) -> Self {
-        BlockInformation {
-            slot: block.slot,
-            block_height: block.block_height,
-            last_valid_blockheight: block.block_height + MAX_RECENT_BLOCKHASHES as u64,
-            cleanup_slot: block.block_height + 1000,
-            blockhash: block.blockhash,
-            commitment_config: block.commitment_config,
-            block_time: block.block_time,
-        }
-    }
     pub fn from_block_info(block_info: &BlockInfo) -> Self {
         BlockInformation {
             slot: block_info.slot,

--- a/core/src/stores/block_information_store.rs
+++ b/core/src/stores/block_information_store.rs
@@ -23,6 +23,17 @@ pub struct BlockInformation {
 }
 
 impl BlockInformation {
+    pub fn from_block(block: &ProducedBlock) -> Self {
+        BlockInformation {
+            slot: block.slot,
+            block_height: block.block_height,
+            last_valid_blockheight: block.block_height + MAX_RECENT_BLOCKHASHES as u64,
+            cleanup_slot: block.block_height + 1000,
+            blockhash: block.blockhash,
+            commitment_config: block.commitment_config,
+            block_time: block.block_time,
+        }
+    }
     pub fn from_block_info(block_info: &BlockInfo) -> Self {
         BlockInformation {
             slot: block_info.slot,

--- a/core/src/stores/block_information_store.rs
+++ b/core/src/stores/block_information_store.rs
@@ -9,6 +9,7 @@ use tokio::sync::RwLock;
 
 use crate::structures::produced_block::ProducedBlock;
 use solana_sdk::hash::Hash;
+use crate::structures::block_info::BlockInfo;
 
 #[derive(Clone, Debug)]
 pub struct BlockInformation {
@@ -22,6 +23,7 @@ pub struct BlockInformation {
 }
 
 impl BlockInformation {
+    // TODO remove
     pub fn from_block(block: &ProducedBlock) -> Self {
         BlockInformation {
             slot: block.slot,
@@ -31,6 +33,17 @@ impl BlockInformation {
             blockhash: block.blockhash,
             commitment_config: block.commitment_config,
             block_time: block.block_time,
+        }
+    }
+    pub fn from_block_info(block_info: &BlockInfo) -> Self {
+        BlockInformation {
+            slot: block_info.slot,
+            block_height: block_info.block_height,
+            last_valid_blockheight: block_info.block_height + MAX_RECENT_BLOCKHASHES as u64,
+            cleanup_slot: block_info.block_height + 1000,
+            blockhash: block_info.blockhash,
+            commitment_config: block_info.commitment_config,
+            block_time: block_info.block_time,
         }
     }
 }

--- a/core/src/stores/block_information_store.rs
+++ b/core/src/stores/block_information_store.rs
@@ -123,7 +123,7 @@ impl BlockInformationStore {
             }
         }
 
-        match self.blocks.entry(block_info.blockhash.clone()) {
+        match self.blocks.entry(block_info.blockhash) {
             dashmap::mapref::entry::Entry::Occupied(entry) => {
                 let should_update = match entry.get().commitment_config.commitment {
                     CommitmentLevel::Finalized => false, // should never update blocks of finalized commitment

--- a/core/src/stores/block_information_store.rs
+++ b/core/src/stores/block_information_store.rs
@@ -7,9 +7,9 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::structures::block_info::BlockInfo;
 use crate::structures::produced_block::ProducedBlock;
 use solana_sdk::hash::Hash;
-use crate::structures::block_info::BlockInfo;
 
 #[derive(Clone, Debug)]
 pub struct BlockInformation {

--- a/core/src/structures/block_info.rs
+++ b/core/src/structures/block_info.rs
@@ -1,4 +1,3 @@
-use solana_sdk::clock::Slot;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
 

--- a/core/src/structures/block_info.rs
+++ b/core/src/structures/block_info.rs
@@ -1,0 +1,12 @@
+use solana_sdk::clock::Slot;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::hash::Hash;
+
+#[derive(Clone, Debug)]
+pub struct BlockInfo {
+    pub slot: u64,
+    pub block_height: u64,
+    pub blockhash: Hash,
+    pub commitment_config: CommitmentConfig,
+    pub block_time: u64,
+}

--- a/core/src/structures/mod.rs
+++ b/core/src/structures/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account_data;
 pub mod account_filter;
+pub mod block_info;
 pub mod epoch;
 pub mod identity_stakes;
 pub mod leader_data;
@@ -9,7 +10,6 @@ pub mod leaderschedule;
 pub mod notifications;
 pub mod prioritization_fee_heap;
 pub mod produced_block;
-pub mod block_info;
 pub mod proxy_request_format;
 pub mod rotating_queue;
 pub mod slot_notification;

--- a/core/src/structures/mod.rs
+++ b/core/src/structures/mod.rs
@@ -9,6 +9,7 @@ pub mod leaderschedule;
 pub mod notifications;
 pub mod prioritization_fee_heap;
 pub mod produced_block;
+pub mod block_info;
 pub mod proxy_request_format;
 pub mod rotating_queue;
 pub mod slot_notification;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use solana_rpc_client_api::response::{RpcContactInfo, RpcVoteAccountStatus};
 use tokio::sync::broadcast::Receiver;
 
+use crate::structures::block_info::BlockInfo;
 use crate::{
     structures::{produced_block::ProducedBlock, slot_notification::SlotNotification},
     traits::subscription_sink::SubscriptionSink,
 };
-use crate::structures::block_info::BlockInfo;
 
 pub type BlockStream = Receiver<ProducedBlock>;
 pub type BlockInfoStream = Receiver<BlockInfo>;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -7,8 +7,10 @@ use crate::{
     structures::{produced_block::ProducedBlock, slot_notification::SlotNotification},
     traits::subscription_sink::SubscriptionSink,
 };
+use crate::structures::block_info::BlockInfo;
 
 pub type BlockStream = Receiver<ProducedBlock>;
+pub type BlockInfoStream = Receiver<BlockInfo>;
 pub type SlotStream = Receiver<SlotNotification>;
 pub type VoteAccountStream = Receiver<RpcVoteAccountStatus>;
 pub type ClusterInfoStream = Receiver<Vec<RpcContactInfo>>;

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -9,9 +9,16 @@ use crate::{
     traits::subscription_sink::SubscriptionSink,
 };
 
+// full blocks, commitment level: processed, confirmed, finalized
+// note: there is no guarantee about the order
+// note: there is no guarantee about the order wrt commitment level
+// note: there is no guarantee about the order wrt block vs block meta
 pub type BlockStream = Receiver<ProducedBlock>;
+// block info (slot, blockhash, etc), commitment level: processed, confirmed, finalized
+// note: there is no guarantee about the order wrt commitment level
 pub type BlockInfoStream = Receiver<BlockInfo>;
 pub type SlotStream = Receiver<SlotNotification>;
+
 pub type VoteAccountStream = Receiver<RpcVoteAccountStatus>;
 pub type ClusterInfoStream = Receiver<Vec<RpcContactInfo>>;
 pub type SubscptionHanderSink = Arc<dyn SubscriptionSink>;

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -196,6 +196,7 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
     let EndpointStreaming {
         // note: blocks_notifier will be dropped at some point
         blocks_notifier,
+        blockinfo_notifier,
         cluster_info_notifier,
         slot_notifier,
         vote_account_notifier,

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -231,8 +231,10 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
 
         let account_service = AccountService::new(account_storage, account_notification_sender);
 
-        account_service
-            .process_account_stream(account_stream.resubscribe(), blockinfo_notifier.resubscribe());
+        account_service.process_account_stream(
+            account_stream.resubscribe(),
+            blockinfo_notifier.resubscribe(),
+        );
 
         account_service
             .populate_from_rpc(

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -54,6 +54,7 @@ use solana_lite_rpc_services::transaction_replayer::TransactionReplayer;
 use solana_lite_rpc_services::tx_sender::TxSender;
 
 use lite_rpc::postgres_logger;
+use solana_lite_rpc_core::structures::block_info::BlockInfo;
 use solana_lite_rpc_prioritization_fees::start_block_priofees_task;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::commitment_config::CommitmentConfig;
@@ -68,7 +69,6 @@ use tokio::sync::RwLock;
 use tokio::time::{timeout, Instant};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
-use solana_lite_rpc_core::structures::block_info::BlockInfo;
 
 async fn get_latest_block_info(
     mut blockinfo_stream: BlockInfoStream,
@@ -247,8 +247,11 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
     };
 
     info!("Waiting for first finalized block info...");
-    let finalized_block_info =
-        get_latest_block_info(blockinfo_notifier.resubscribe(), CommitmentConfig::finalized()).await;
+    let finalized_block_info = get_latest_block_info(
+        blockinfo_notifier.resubscribe(),
+        CommitmentConfig::finalized(),
+    )
+    .await;
     info!("Got finalized block info: {:?}", finalized_block_info.slot);
 
     let (epoch_data, _current_epoch_info) = EpochCache::bootstrap_epoch(&rpc_client).await?;

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -232,7 +232,7 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
         let account_service = AccountService::new(account_storage, account_notification_sender);
 
         account_service
-            .process_account_stream(account_stream.resubscribe(), blocks_notifier.resubscribe());
+            .process_account_stream(account_stream.resubscribe(), blockinfo_notifier.resubscribe());
 
         account_service
             .populate_from_rpc(

--- a/lite-rpc/src/main.rs
+++ b/lite-rpc/src/main.rs
@@ -277,6 +277,7 @@ pub async fn start_lite_rpc(args: Config, rpc_client: Arc<RpcClient>) -> anyhow:
     // to avoid laggin we resubscribe to block notification
     let data_caching_service = data_cache_service.listen(
         blocks_notifier.resubscribe(),
+        blockinfo_notifier.resubscribe(),
         slot_notifier.resubscribe(),
         cluster_info_notifier,
         vote_account_notifier,

--- a/lite-rpc/src/service_spawner.rs
+++ b/lite-rpc/src/service_spawner.rs
@@ -1,3 +1,4 @@
+use solana_lite_rpc_core::types::BlockInfoStream;
 use solana_lite_rpc_core::{
     stores::data_cache::DataCache,
     structures::notifications::NotificationSender,
@@ -14,7 +15,6 @@ use solana_lite_rpc_services::{
     tx_sender::TxSender,
 };
 use std::time::Duration;
-use solana_lite_rpc_core::types::BlockInfoStream;
 
 pub struct ServiceSpawner {
     pub prometheus_addr: String,

--- a/lite-rpc/src/service_spawner.rs
+++ b/lite-rpc/src/service_spawner.rs
@@ -14,6 +14,8 @@ use solana_lite_rpc_services::{
     tx_sender::TxSender,
 };
 use std::time::Duration;
+use solana_lite_rpc_core::types::BlockInfoStream;
+
 pub struct ServiceSpawner {
     pub prometheus_addr: String,
     pub data_cache: DataCache,
@@ -38,9 +40,11 @@ impl ServiceSpawner {
         }
     }
 
-    pub async fn spawn_data_caching_service(
+    // TODO remove
+    pub async fn _spawn_data_caching_service(
         &self,
         block_notifier: BlockStream,
+        blockinfo_notifier: BlockInfoStream,
         slot_notification: SlotStream,
         cluster_info_notification: ClusterInfoStream,
         va_notification: VoteAccountStream,
@@ -52,6 +56,7 @@ impl ServiceSpawner {
 
         data_service.listen(
             block_notifier,
+            blockinfo_notifier,
             slot_notification,
             cluster_info_notification,
             va_notification,

--- a/services/src/data_caching_service.rs
+++ b/services/src/data_caching_service.rs
@@ -69,6 +69,11 @@ impl DataCachingService {
                     }
                 };
 
+                // note: most likely the block has been added from blockinfo_notifier stream already
+                block_information_store_block_info
+                    .add_block(BlockInformation::from_block(&block))
+                    .await;
+
                 let confirmation_status = match block.commitment_config.commitment {
                     CommitmentLevel::Finalized => TransactionConfirmationStatus::Finalized,
                     CommitmentLevel::Confirmed => TransactionConfirmationStatus::Confirmed,


### PR DESCRIPTION
changes dependency of block_information_store to block stream->block info stream; this should propagate finalized block information faster

the important change is inside the `.listen` method: look for _block_information_store_block_info_ as this is updated from blockinfo_stream