### PR TITLE
fix postgres ssl algo issue - Algorithm (RC2-40-CBC : 0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ RUN cargo build --release --bin lite-rpc --bin solana-lite-rpc-quic-forward-prox
 
 FROM debian:bookworm-slim as run
 RUN apt-get update && apt-get -y install ca-certificates libc6 libssl3 libssl-dev openssl
+
 COPY --from=build /app/target/release/solana-lite-rpc-quic-forward-proxy /usr/local/bin/
 COPY --from=build /app/target/release/lite-rpc /usr/local/bin/
+COPY openssl-legacy.cnf /etc/ssl/openssl-legacy.cnf
 
+ENV OPENSSL_CONF=/etc/ssl/openssl-legacy.cnf
 CMD lite-rpc


### PR DESCRIPTION
### Problem

PostgreSQL connection fails using TLS with this with recent docker image:

> 2024-03-20T12:21:52.444 app[7842094c44d538] ams [info] PostgreSQL session cache: Identity
2024-03-20T12:21:52.444 app[7842094c44d538] ams [info] Caused by:
2024-03-20T12:21:52.444 app[7842094c44d538] ams [info] error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
ErrorStack([Error { code: 50856204, library: "digital envelope routines", function: "inner_evp_generic_fetch", reason: "unsupported", file: "../crypto/evp/evp_fetch.c", line: 373, data: "Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()" }]))

workaround:
disable postgres with `PG_ENABLED=false`

