### PR TITLE
postgres config error handling

### DIFF
--- a/benchrunner-service/src/postgres/postgres_session.rs
+++ b/benchrunner-service/src/postgres/postgres_session.rs
@@ -81,7 +81,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()?;
+        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+            .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {
             Self::spawn_connection(pg_config, NoTls).await?
@@ -90,14 +91,14 @@ impl PostgresSession {
                 ca_pem_b64,
                 client_pks_b64,
                 client_pks_pass,
-            } = ssl.as_ref().unwrap();
+            } = ssl.as_ref().context("Postgres ssl config").unwrap();
 
             let ca_pem = BinaryEncoding::Base64
                 .decode(ca_pem_b64)
-                .context("ca pem decode")?;
+                .context("Postgres ca pem decode")?;
             let client_pks = BinaryEncoding::Base64
                 .decode(client_pks_b64)
-                .context("client pks decode")?;
+                .context("Postgres client pks decode")?;
 
             let connector = TlsConnector::builder()
                 .add_root_certificate(Certificate::from_pem(&ca_pem)?)

--- a/benchrunner-service/src/postgres/postgres_session.rs
+++ b/benchrunner-service/src/postgres/postgres_session.rs
@@ -81,7 +81,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+        let pg_config = pg_config
+            .parse::<tokio_postgres::Config>()
             .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {

--- a/blockstore/src/block_stores/postgres/postgres_session.rs
+++ b/blockstore/src/block_stores/postgres/postgres_session.rs
@@ -29,7 +29,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()?;
+        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+            .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {
             Self::spawn_connection(pg_config, NoTls).await?
@@ -38,14 +39,14 @@ impl PostgresSession {
                 ca_pem_b64,
                 client_pks_b64,
                 client_pks_pass,
-            } = ssl.as_ref().unwrap();
+            } = ssl.as_ref().context("Postgres ssl config").unwrap();
 
             let ca_pem = BinaryEncoding::Base64
                 .decode(ca_pem_b64)
-                .context("ca pem decode")?;
+                .context("Postgres ca pem decode")?;
             let client_pks = BinaryEncoding::Base64
                 .decode(client_pks_b64)
-                .context("client pks decode")?;
+                .context("Postgres client pks decode")?;
 
             let connector = TlsConnector::builder()
                 .add_root_certificate(Certificate::from_pem(&ca_pem)?)

--- a/blockstore/src/block_stores/postgres/postgres_session.rs
+++ b/blockstore/src/block_stores/postgres/postgres_session.rs
@@ -29,7 +29,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+        let pg_config = pg_config
+            .parse::<tokio_postgres::Config>()
             .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {

--- a/lite-rpc/src/postgres_logger/postgres_session.rs
+++ b/lite-rpc/src/postgres_logger/postgres_session.rs
@@ -18,7 +18,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+        let pg_config = pg_config
+            .parse::<tokio_postgres::Config>()
             .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {

--- a/lite-rpc/src/postgres_logger/postgres_session.rs
+++ b/lite-rpc/src/postgres_logger/postgres_session.rs
@@ -18,7 +18,8 @@ impl PostgresSession {
     pub async fn new(
         PostgresSessionConfig { pg_config, ssl }: PostgresSessionConfig,
     ) -> anyhow::Result<Self> {
-        let pg_config = pg_config.parse::<tokio_postgres::Config>()?;
+        let pg_config = pg_config.parse::<tokio_postgres::Config>()
+            .context("Postgres config parser")?;
 
         let client = if let SslMode::Disable = pg_config.get_ssl_mode() {
             Self::spawn_connection(pg_config, NoTls).await?
@@ -27,14 +28,14 @@ impl PostgresSession {
                 ca_pem_b64,
                 client_pks_b64,
                 client_pks_pass,
-            } = ssl.as_ref().unwrap();
+            } = ssl.as_ref().context("Postgres ssl config").unwrap();
 
             let ca_pem = BinaryEncoding::Base64
                 .decode(ca_pem_b64)
-                .context("ca pem decode")?;
+                .context("Postgres ca pem decode")?;
             let client_pks = BinaryEncoding::Base64
                 .decode(client_pks_b64)
-                .context("client pks decode")?;
+                .context("Postgres client pks decode")?;
 
             let connector = TlsConnector::builder()
                 .add_root_certificate(Certificate::from_pem(&ca_pem)?)


### PR DESCRIPTION

## Problem:
The error message lacks context:
![image](https://github.com/blockworks-foundation/lite-rpc/assets/95291500/ee1b752c-53bb-411a-81e3-55a2a7cea87e)


## Solution

> 2024-05-03T06:07:40.443775Z ERROR lite_rpc: Services quit unexpectedly Err(postgres config parser
