### PR TITLE
benchrunner status from websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,11 +578,13 @@ dependencies = [
  "dirs",
  "futures",
  "itertools 0.10.5",
+ "jsonrpsee-types 0.22.5",
  "lazy_static",
  "log",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "reqwest",
+ "scopeguard",
  "serde",
  "serde_json",
  "solana-lite-rpc-util",
@@ -595,6 +597,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "websocket-tungstenite-retry",
 ]
 
 [[package]]
@@ -2341,7 +2344,7 @@ dependencies = [
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
@@ -2384,7 +2387,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
  "parking_lot",
  "rand 0.8.5",
  "rustc-hash",
@@ -2407,7 +2410,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -2440,7 +2443,7 @@ dependencies = [
  "http",
  "hyper",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -2468,6 +2471,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,7 +2491,7 @@ checksum = "7c7cbb3447cf14fd4d2f407c3cc96e6c9634d5440aa1fbed868a31f3c02b27f0"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
 ]
 
 [[package]]
@@ -2487,7 +2503,7 @@ dependencies = [
  "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.20.3",
  "url",
 ]
 
@@ -4150,6 +4166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,7 +4317,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha-1 0.9.8",
 ]
 
 [[package]]
@@ -5085,8 +5112,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.20.1",
+ "tungstenite 0.20.1",
  "url",
 ]
 
@@ -6056,6 +6083,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.17.3",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
@@ -6065,7 +6106,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
 ]
 
@@ -6307,6 +6348,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha-1 0.10.1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -6597,6 +6658,23 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "websocket-tungstenite-retry"
+version = "0.6.0"
+source = "git+https://github.com/grooviegermanikus/websocket-tungstenite-retry.git?tag=v0.8.0#2f423ed40171b023aa0d5c67287ad778958a6722"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.17.2",
+ "tokio-util",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "reqwest",
- "scopeguard",
  "serde",
  "serde_json",
  "solana-lite-rpc-util",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -13,6 +13,10 @@ name = "benchnew"
 path = "src/benchnew.rs"
 
 [dependencies]
+
+websocket-tungstenite-retry = { git = "https://github.com/grooviegermanikus/websocket-tungstenite-retry.git", tag = "v0.8.0" }
+jsonrpsee-types = "0.22.2"
+
 clap = { workspace = true }
 csv = "1.2.1"
 dirs = "5.0.0"
@@ -38,6 +42,7 @@ spl-memo = "4.0.0"
 url = "*"
 reqwest = "0.11.26"
 lazy_static = "1.4.0"
+scopeguard = "1.2.0"
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -42,7 +42,6 @@ spl-memo = "4.0.0"
 url = "*"
 reqwest = "0.11.26"
 lazy_static = "1.4.0"
-scopeguard = "1.2.0"
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/bench/src/benches/confirmation_rate.rs
+++ b/bench/src/benches/confirmation_rate.rs
@@ -12,6 +12,7 @@ use crate::benches::rpc_interface::{
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::signature::{read_keypair_file, Keypair, Signature, Signer};
 use url::Url;
+use solana_lite_rpc_util::obfuscate_rpcurl;
 
 #[derive(Clone, Copy, Debug, Default, serde::Serialize)]
 pub struct Metric {
@@ -29,7 +30,7 @@ pub struct Metric {
 pub async fn confirmation_rate(
     payer_path: &Path,
     rpc_url: String,
-    tx_status_websocket_addr: String,
+    tx_status_websocket_addr: Option<String>,
     tx_params: BenchmarkTransactionParams,
     max_timeout: Duration,
     txs_per_run: usize,
@@ -39,8 +40,11 @@ pub async fn confirmation_rate(
 
     assert!(num_of_runs > 0, "num_of_runs must be greater than 0");
 
-    let rpc = Arc::new(RpcClient::new(rpc_url));
-    info!("RPC: {}", rpc.as_ref().url());
+    let rpc = Arc::new(RpcClient::new(rpc_url.clone()));
+    info!("RPC: {}", obfuscate_rpcurl(&rpc.as_ref().url()));
+    
+    let ws_addr = tx_status_websocket_addr.unwrap_or_else(|| rpc_url.replace("http:", "ws:").replace("https:", "wss:"));
+    info!("WS ADDR: {}", obfuscate_rpcurl(&ws_addr));
 
     let payer: Arc<Keypair> = Arc::new(read_keypair_file(payer_path).unwrap());
     info!("Payer: {}", payer.pubkey().to_string());
@@ -48,7 +52,7 @@ pub async fn confirmation_rate(
     let mut rpc_results = Vec::with_capacity(num_of_runs);
 
     for _ in 0..num_of_runs {
-        match send_bulk_txs_and_wait(&rpc, Url::parse(&tx_status_websocket_addr).expect("Invalid Url"), &payer, txs_per_run, &tx_params, max_timeout)
+        match send_bulk_txs_and_wait(&rpc, Url::parse(&ws_addr).expect("Invalid Url"), &payer, txs_per_run, &tx_params, max_timeout)
             .await
             .context("send bulk tx and wait")
         {
@@ -130,9 +134,9 @@ pub async fn send_bulk_txs_and_wait(
             }
             ConfirmationResponseFromRpc::Timeout(elapsed) => {
                 debug!(
-                    "Signature {} not confirmed after {:.02}ms",
+                    "Signature {} not confirmed after {:.03}s",
                     tx_sig,
-                    elapsed.as_secs_f32() * 1000.0
+                    elapsed.as_secs_f32()
                 );
                 tx_sent += 1;
                 tx_unconfirmed += 1;

--- a/bench/src/benches/confirmation_slot.rs
+++ b/bench/src/benches/confirmation_slot.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::str::FromStr;
 use std::time::Duration;
 
 use crate::benches::rpc_interface::{
@@ -13,8 +14,10 @@ use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::signature::{read_keypair_file, Signature, Signer};
 use solana_sdk::transaction::VersionedTransaction;
 use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+use solana_sdk::pubkey::Pubkey;
 use tokio::time::{sleep, Instant};
 use url::Url;
+use crate::benches::tx_status_websocket_collector::start_tx_status_collector;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Metric {
@@ -46,6 +49,7 @@ pub async fn confirmation_slot(
     payer_path: &Path,
     rpc_a_url: String,
     rpc_b_url: String,
+    tx_status_websocket_addr: String,
     tx_params: BenchmarkTransactionParams,
     max_timeout: Duration,
     num_of_runs: usize,
@@ -66,12 +70,20 @@ pub async fn confirmation_slot(
 
     let mut rng = create_rng(None);
     let payer = read_keypair_file(payer_path).expect("payer file");
-    info!("Payer: {}", payer.pubkey().to_string());
+    let payer_pubkey = payer.pubkey();
+    info!("Payer: {}", payer_pubkey.to_string());
     // let mut ping_thing_tasks = vec![];
+
+    // FIXME
+    // let (tx_status_map, jh_collector) = start_tx_status_collector(Url::parse(&tx_status_websocket_addr).unwrap(), payer.pubkey(), CommitmentConfig::confirmed()).await;
 
     for _ in 0..num_of_runs {
         let rpc_a = create_rpc_client(&rpc_a_url);
         let rpc_b = create_rpc_client(&rpc_b_url);
+
+        let tx_status_websocket_addr_a = Url::parse(&tx_status_websocket_addr).expect("Invalid URL");
+        let tx_status_websocket_addr_b = Url::parse(&tx_status_websocket_addr).expect("Invalid URL");
+
         // measure network time to reach the respective RPC endpoints,
         // used to mitigate the difference in distance by delaying the txn sending
         let time_a = rpc_roundtrip_duration(&rpc_a).await?.as_secs_f64();
@@ -95,13 +107,13 @@ pub async fn confirmation_slot(
         let a_task = tokio::spawn(async move {
             sleep(Duration::from_secs_f64(a_delay)).await;
             debug!("(A) sending tx {}", rpc_a_tx.signatures[0]);
-            send_and_confirm_transaction(&rpc_a, rpc_a_tx, max_timeout).await
+            send_and_confirm_transaction(&rpc_a, tx_status_websocket_addr_a, payer_pubkey, rpc_a_tx, max_timeout).await
         });
 
         let b_task = tokio::spawn(async move {
             sleep(Duration::from_secs_f64(b_delay)).await;
             debug!("(B) sending tx {}", rpc_b_tx.signatures[0]);
-            send_and_confirm_transaction(&rpc_b, rpc_b_tx, max_timeout).await
+            send_and_confirm_transaction(&rpc_b, tx_status_websocket_addr_b, payer_pubkey, rpc_b_tx, max_timeout).await
         });
 
         let (a, b) = tokio::join!(a_task, b_task);
@@ -156,11 +168,13 @@ async fn create_tx(
 
 async fn send_and_confirm_transaction(
     rpc: &RpcClient,
+    tx_status_websocket_addr: Url,
+    payer_pubkey: Pubkey,
     tx: VersionedTransaction,
     max_timeout: Duration,
 ) -> anyhow::Result<ConfirmationResponseFromRpc> {
     let result_vec: Vec<(Signature, ConfirmationResponseFromRpc)> =
-        send_and_confirm_bulk_transactions(rpc, &[tx], max_timeout).await?;
+        send_and_confirm_bulk_transactions(rpc, tx_status_websocket_addr, payer_pubkey, &[tx], max_timeout).await?;
     assert_eq!(result_vec.len(), 1, "expected 1 result");
     let (_sig, confirmation_response) = result_vec.into_iter().next().unwrap();
 

--- a/bench/src/benches/confirmation_slot.rs
+++ b/bench/src/benches/confirmation_slot.rs
@@ -68,7 +68,7 @@ pub async fn confirmation_slot(
     let ws_addr_b = tx_status_websocket_addr_b.unwrap_or_else(|| rpc_b_url.replace("http:", "ws:").replace("https:", "wss:"));
     let ws_addr_a = Url::parse(&ws_addr_a).expect("Invalid URL");
     let ws_addr_b = Url::parse(&ws_addr_b).expect("Invalid URL");
-    
+
     let rpc_a_url =
         Url::parse(&rpc_a_url).map_err(|e| anyhow!("Failed to parse RPC A URL: {}", e))?;
     let rpc_b_url =
@@ -86,7 +86,7 @@ pub async fn confirmation_slot(
     for _ in 0..num_of_runs {
         let rpc_a = create_rpc_client(&rpc_a_url);
         let rpc_b = create_rpc_client(&rpc_b_url);
-        
+
         let ws_addr_a = ws_addr_a.clone();
         let ws_addr_b = ws_addr_b.clone();
 

--- a/bench/src/benches/mod.rs
+++ b/bench/src/benches/mod.rs
@@ -2,3 +2,4 @@ pub mod api_load;
 pub mod confirmation_rate;
 pub mod confirmation_slot;
 pub mod rpc_interface;
+mod tx_status_websocket_collector;

--- a/bench/src/benches/rpc_interface.rs
+++ b/bench/src/benches/rpc_interface.rs
@@ -18,7 +18,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use dashmap::mapref::multiple::RefMulti;
-use scopeguard::defer;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_rpc_client_api::response::{Response, RpcBlockUpdate, RpcResponseContext, SlotUpdate};
@@ -66,8 +65,7 @@ pub async fn send_and_confirm_bulk_transactions(
     };
 
     // note: we get confirmed but never finaliized
-    let (tx_status_map, jh_collector) = start_tx_status_collector(tx_status_websocket_addr.clone(), payer_pubkey, CommitmentConfig::confirmed()).await;
-    defer!(jh_collector.abort());
+    let (tx_status_map, _jh_collector) = start_tx_status_collector(tx_status_websocket_addr.clone(), payer_pubkey, CommitmentConfig::confirmed()).await;
 
     let started_at = Instant::now();
     trace!(

--- a/bench/src/benches/rpc_interface.rs
+++ b/bench/src/benches/rpc_interface.rs
@@ -116,14 +116,14 @@ pub async fn send_and_confirm_bulk_transactions(
     }
     let elapsed = started_at.elapsed();
     debug!(
-        "{} transactions sent successfully in {:.02}ms",
+        "send_transaction successful for {} txs in {:.03}s",
         num_sent_ok,
-        elapsed.as_secs_f32() * 1000.0
+        elapsed.as_secs_f32()
     );
     debug!(
-        "{} transactions failed to send in {:.02}ms",
+        "send_transaction failed to send {} txs in {:.03}s",
         num_sent_failed,
-        elapsed.as_secs_f32() * 1000.0
+        elapsed.as_secs_f32()
     );
 
     if num_sent_failed > 0 {
@@ -146,6 +146,7 @@ pub async fn send_and_confirm_bulk_transactions(
 
     // items get moved from pending_status_set to result_status_map
 
+    debug!("Wating for transaction confirmations ..");
     let started_at = Instant::now();
     let timeout_at = started_at + max_timeout;
     // "poll" the status dashmap
@@ -208,8 +209,7 @@ pub async fn send_and_confirm_bulk_transactions(
 
         if pending_status_set.is_empty() {
             debug!(
-                "All transactions confirmed after {} iterations / {:?}",
-                iteration,
+                "All transactions confirmed after {:?}",
                 started_at.elapsed()
             );
             break 'polling_loop;
@@ -217,8 +217,8 @@ pub async fn send_and_confirm_bulk_transactions(
 
         if Instant::now() > timeout_at {
             warn!(
-                "Timeout waiting for transactions to confirm after {} iterations",
-                iteration
+                "Timeout waiting for transactions to confirm after {:?}",
+                started_at.elapsed()
             );
             break 'polling_loop;
         }

--- a/bench/src/benches/rpc_interface.rs
+++ b/bench/src/benches/rpc_interface.rs
@@ -162,7 +162,7 @@ pub async fn send_and_confirm_bulk_transactions(
             // note that we will see tx_sigs we did not send
             let (tx_sig, confirmed_slot) = multi.pair();
 
-            // status is confirmed or finalized
+            // status is confirmed
             if pending_status_set.remove(&tx_sig) {
                 trace!("take status for sig {:?} and confirmed_slot: {:?} from websocket source", tx_sig, confirmed_slot);
                 let prev_value = result_status_map.insert(
@@ -170,7 +170,7 @@ pub async fn send_and_confirm_bulk_transactions(
                     ConfirmationResponseFromRpc::Success(
                         send_slot,
                         *confirmed_slot,
-                        // note: this is not optimal
+                        // note: this is not optimal as we do not cover finalized here
                         TransactionConfirmationStatus::Confirmed,
                         elapsed,
                     ),

--- a/bench/src/benches/tx_status_websocket_collector.rs
+++ b/bench/src/benches/tx_status_websocket_collector.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use dashmap::{DashMap, DashSet};
-use log::{info, trace};
+use log::{debug, info, trace};
 use serde_json::json;
 use solana_rpc_client_api::response::{Response, RpcBlockUpdate};
 use solana_sdk::clock::Slot;
@@ -15,7 +15,6 @@ use url::Url;
 use websocket_tungstenite_retry::websocket_stable;
 use websocket_tungstenite_retry::websocket_stable::WsMessage;
 
-// TODO void race condition when this is not started up fast enough to catch transaction
 // returns map of transaction signatures to the slot they were confirmed
 pub async fn start_tx_status_collector(ws_url: Url, payer_pubkey: Pubkey, commitment_config: CommitmentConfig)
                                        -> (Arc<DashMap<Signature, Slot>>, AbortHandle) {
@@ -44,7 +43,6 @@ pub async fn start_tx_status_collector(ws_url: Url, payer_pubkey: Pubkey, commit
     ).await
     .expect("Failed to connect to websocket");
 
-
     let mut channel = web_socket_slots.subscribe_message_channel();
 
     let observed_transactions: Arc<DashMap<Signature, Slot>> = Arc::new(DashMap::with_capacity(64));
@@ -54,7 +52,6 @@ pub async fn start_tx_status_collector(ws_url: Url, payer_pubkey: Pubkey, commit
         let started_at = Instant::now();
 
         while let Ok(msg) = channel.recv().await {
-            // TOOD use this to know when we are subscribed
             if let WsMessage::Text(payload) = msg {
                 let ws_result: jsonrpsee_types::SubscriptionResponse<Response<RpcBlockUpdate>> =
                     serde_json::from_str(&payload).unwrap();
@@ -63,14 +60,13 @@ pub async fn start_tx_status_collector(ws_url: Url, payer_pubkey: Pubkey, commit
                 if let Some(tx_sigs_from_block) = block_update.value.block.and_then(|b| b.signatures) {
                     for tx_sig in tx_sigs_from_block {
                         let tx_sig = Signature::from_str(&tx_sig).unwrap();
-                        trace!("Transaction signature: {} - slot {}", tx_sig, slot);
+                        debug!("Transaction signature found in block: {} - slot {}", tx_sig, slot);
                         observed_transactions_write.entry(tx_sig).or_insert(slot);
                     }
                 }
             }
         }
     });
-
 
     (observed_transactions, jh.abort_handle())
 }

--- a/bench/src/benches/tx_status_websocket_collector.rs
+++ b/bench/src/benches/tx_status_websocket_collector.rs
@@ -1,0 +1,80 @@
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use dashmap::{DashMap, DashSet};
+use log::info;
+use serde_json::json;
+use solana_rpc_client_api::response::{Response, RpcBlockUpdate};
+use solana_sdk::clock::Slot;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
+use tokio::task::AbortHandle;
+use tokio::time::sleep;
+use url::Url;
+use websocket_tungstenite_retry::websocket_stable;
+use websocket_tungstenite_retry::websocket_stable::WsMessage;
+
+// TODO void race condition when this is not started up fast enough to catch transaction
+// returns map of transaction signatures to the slot they were confirmed
+pub async fn start_tx_status_collector(ws_url: Url, payer_pubkey: Pubkey, commitment_config: CommitmentConfig)
+                                       -> (Arc<DashMap<Signature, Slot>>, AbortHandle) {
+    // e.g. "commitment"
+    let commitment_str = format!("{:?}", commitment_config);
+
+    let mut web_socket_slots = websocket_stable::StableWebSocket::new_with_timeout(
+        ws_url,
+        json!({
+          "jsonrpc": "2.0",
+          "id": "1",
+          "method": "blockSubscribe",
+          "params": [
+            {
+              "mentionsAccountOrProgram": payer_pubkey.to_string(),
+            },
+            {
+              "commitment": commitment_str,
+              "encoding": "base64",
+              "showRewards": false,
+              "transactionDetails": "signatures"
+            }
+          ]
+        }),
+        Duration::from_secs(10),
+    ).await
+    .expect("Failed to connect to websocket");
+
+
+    let mut channel = web_socket_slots.subscribe_message_channel();
+
+    let observed_transactions: Arc<DashMap<Signature, Slot>> = Arc::new(DashMap::with_capacity(64));
+
+    let observed_transactions_write = observed_transactions.clone();
+    let jh = tokio::spawn(async move {
+        let started_at = Instant::now();
+
+        while let Ok(msg) = channel.recv().await {
+            // TOOD use this to know when we are subscribed
+            info!("SOME MESSGE FROM SUbsCRIPTN");
+            if let WsMessage::Text(payload) = msg {
+                let ws_result: jsonrpsee_types::SubscriptionResponse<Response<RpcBlockUpdate>> =
+                    serde_json::from_str(&payload).unwrap();
+                let block_update = ws_result.params.result;
+                let slot = block_update.value.slot;
+                if let Some(tx_sigs_from_block) = block_update.value.block.and_then(|b| b.signatures) {
+                    for tx_sig in tx_sigs_from_block {
+                        let tx_sig = Signature::from_str(&tx_sig).unwrap();
+                        info!("Transaction signature: {} _> slot {}", tx_sig, slot);
+                        info!("status map size: {} - up {:?}", observed_transactions_write.len(), started_at.elapsed());
+                        observed_transactions_write.entry(tx_sig).or_insert(slot);
+                    }
+                }
+            }
+        }
+    });
+
+    // FIXME avoid race condition
+    sleep(Duration::from_secs(3)).await;
+
+    (observed_transactions, jh.abort_handle())
+}

--- a/bench/src/benchnew.rs
+++ b/bench/src/benchnew.rs
@@ -39,6 +39,8 @@ enum SubCommand {
         payer_path: PathBuf,
         #[clap(short, long)]
         rpc_url: String,
+        #[clap(short = 'w', long)]
+        tx_status_websocket_addr: Option<String>,
         #[clap(short, long)]
         size_tx: TxSize,
         /// Maximum confirmation time in milliseconds. After this, the txn is considered unconfirmed
@@ -65,6 +67,10 @@ enum SubCommand {
         #[clap(short, long)]
         #[arg(short = 'b')]
         rpc_b: String,
+        #[clap(long)]
+        tx_status_websocket_addr_a: Option<String>,
+        #[clap(long)]
+        tx_status_websocket_addr_b: Option<String>,
         #[clap(short, long)]
         size_tx: TxSize,
         /// Maximum confirmation time in milliseconds. After this, the txn is considered unconfirmed
@@ -108,6 +114,7 @@ async fn main() {
         SubCommand::ConfirmationRate {
             payer_path,
             rpc_url,
+            tx_status_websocket_addr,
             size_tx,
             max_timeout_ms,
             txs_per_run,
@@ -116,6 +123,7 @@ async fn main() {
         } => confirmation_rate(
             &payer_path,
             rpc_url,
+            tx_status_websocket_addr,
             BenchmarkTransactionParams {
                 tx_size: size_tx,
                 cu_price_micro_lamports: cu_price,
@@ -130,6 +138,8 @@ async fn main() {
             payer_path,
             rpc_a,
             rpc_b,
+            tx_status_websocket_addr_a,
+            tx_status_websocket_addr_b,
             size_tx,
             max_timeout_ms,
             num_of_runs,
@@ -139,6 +149,8 @@ async fn main() {
             &payer_path,
             rpc_a,
             rpc_b,
+            tx_status_websocket_addr_a,
+            tx_status_websocket_addr_b,
             BenchmarkTransactionParams {
                 tx_size: size_tx,
                 cu_price_micro_lamports: cu_price,

--- a/bench/src/benchnew.rs
+++ b/bench/src/benchnew.rs
@@ -39,6 +39,10 @@ enum SubCommand {
         payer_path: PathBuf,
         #[clap(short, long)]
         rpc_url: String,
+        /// Set websocket source (blockSubscribe method) for transaction status updates.
+        /// You might want to send tx to one RPC and listen to another (reliable) RPC for status updates.
+        /// Not all RPC nodes support this method.
+        /// If not provided, the RPC URL is used to derive the websocket URL.
         #[clap(short = 'w', long)]
         tx_status_websocket_addr: Option<String>,
         #[clap(short, long)]

--- a/bench/src/service_adapter_new.rs
+++ b/bench/src/service_adapter_new.rs
@@ -7,10 +7,12 @@ use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::signature::Keypair;
 use std::sync::Arc;
 use std::time::Duration;
+use url::Url;
 
 pub async fn benchnew_confirmation_rate_servicerunner(
     bench_config: &BenchConfig,
     rpc_addr: String,
+    tx_status_websocket_addr: String,
     funded_payer: Keypair,
 ) -> confirmation_rate::Metric {
     let rpc = Arc::new(RpcClient::new(rpc_addr));
@@ -21,6 +23,7 @@ pub async fn benchnew_confirmation_rate_servicerunner(
     let max_timeout = Duration::from_secs(60);
     let result = send_bulk_txs_and_wait(
         &rpc,
+        Url::parse(&tx_status_websocket_addr).expect("Invalid URL"),
         &funded_payer,
         bench_config.tx_count,
         &tx_params,

--- a/bench/src/service_adapter_new.rs
+++ b/bench/src/service_adapter_new.rs
@@ -12,18 +12,21 @@ use url::Url;
 pub async fn benchnew_confirmation_rate_servicerunner(
     bench_config: &BenchConfig,
     rpc_addr: String,
-    tx_status_websocket_addr: String,
+    tx_status_websocket_addr: Option<String>,
     funded_payer: Keypair,
 ) -> confirmation_rate::Metric {
-    let rpc = Arc::new(RpcClient::new(rpc_addr));
+    let rpc = Arc::new(RpcClient::new(rpc_addr.clone()));
     let tx_params = BenchmarkTransactionParams {
         tx_size: bench_config.tx_size,
         cu_price_micro_lamports: bench_config.cu_price_micro_lamports,
     };
     let max_timeout = Duration::from_secs(60);
+
+    let ws_addr = tx_status_websocket_addr.unwrap_or_else(|| rpc_addr.replace("http:", "ws:").replace("https:", "wss:"));
+
     let result = send_bulk_txs_and_wait(
         &rpc,
-        Url::parse(&tx_status_websocket_addr).expect("Invalid URL"),
+        Url::parse(&ws_addr).expect("Invalid WS URL"),
         &funded_payer,
         bench_config.tx_count,
         &tx_params,

--- a/benchrunner-service/README.md
+++ b/benchrunner-service/README.md
@@ -6,25 +6,34 @@ Hardware: recommend 1024MB RAM, 2 vCPUs, small disk
 
 
 ### Environment Variables
-| Environment Variable | Purpose                                               | Required?     | Default Value |
-|----------------------|-------------------------------------------------------|---------------|---------------|
-| `PG_ENABLED`         | Enable writing to PostgreSQL                          | No            | false         |
-| `PG_CONFIG`          | PostgreSQL connection string                          | if PG_ENABLED |               |
-| `TENANT1_ID`         | Technical ID for the tenant                           | Yes           |               |
-| `TENANT1_RPC_ADDR`   | RPC address for the target RPC node                   | Yes           |               |
-| `TENANT2_..          | more tenants can be added using TENANT2, TENANT3, ... |            |               |
+| Environment Variable | Purpose                                               | Required?    | Default Value                              |
+|----------------------|-------------------------------------------------------|--------------|--------------------------------------------|
+| `PG_ENABLED`         | Enable writing to PostgreSQL                          | No           | false                                      |
+| `PG_CONFIG`          | PostgreSQL connection string                          | if PG_ENABLED |                                            |
+| `TENANT1_ID`         | Technical ID for the tenant                           | Yes          |                                            |
+| `TENANT1_RPC_ADDR`   | RPC address for the target RPC node                   | Yes          |                                            |
+| `TENANT1_TX_STATUS_WS_ADDR`   | Websocket source for tx status               |No            | RPC Url<br/>(replacing schema with ws/wss) |
+| `TENANT2_..          | more tenants can be added using TENANT2, TENANT3, ... |              |                                            |
 
 ### Command-line Arguments
 ```
 Options:
-  -b, --bench-interval <BENCH_INTERVAL>
-          interval in milliseconds to run the benchmark [default: 60000]
-  -n, --tx-count <TX_COUNT>
-          [default: 10]
+  -p, --payer-path <PAYER_PATH>
+          
+  -r, --rpc-url <RPC_URL>
+          
+  -w, --tx-status-websocket-addr <TX_STATUS_WEBSOCKET_ADDR>
+          Set websocket source (blockSubscribe method) for transaction status updates. You might want to send tx to one RPC and listen to another (reliable) RPC for status updates. Not all RPC nodes support this method. If not provided, the RPC URL is used to derive the websocket URL
   -s, --size-tx <SIZE_TX>
-          [default: small] [possible values: small, large]
-  -p, --prio-fees <PRIO_FEES>
-          [default: 0]
+          [possible values: small, large]
+  -m, --max-timeout-ms <MAX_TIMEOUT_MS>
+          Maximum confirmation time in milliseconds. After this, the txn is considered unconfirmed [default: 15000]
+  -t, --txs-per-run <TXS_PER_RUN>
+          
+  -n, --num-of-runs <NUM_OF_RUNS>
+          
+  -f, --cu-price <CU_PRICE>
+          The CU price in micro lamports [default: 300]
 ```
 
 ```bash

--- a/benchrunner-service/src/args.rs
+++ b/benchrunner-service/src/args.rs
@@ -6,6 +6,7 @@ pub struct TenantConfig {
     // technical identifier for the tenant, e.g. "solana-rpc"
     pub tenant_id: String,
     pub rpc_addr: String,
+    // needs to point to a reliable websocket server that can be used to get tx status
     pub tx_status_ws_addr: String,
 }
 
@@ -49,6 +50,14 @@ pub fn read_tenant_configs(env_vars: Vec<(String, String)>) -> Vec<TenantConfig>
                 .iter()
                 .exactly_one()
                 .expect("need RPC_ADDR")
+                .1
+                .to_string(),
+            tx_status_ws_addr: v
+                .iter()
+                .find(|(v, _)| *v == format!("TENANT{}_TX_STATUS_WS_ADDR", tc))
+                .iter()
+                .exactly_one()
+                .expect("need TX_STATUS_WS_ADDR")
                 .1
                 .to_string(),
         })

--- a/benchrunner-service/src/args.rs
+++ b/benchrunner-service/src/args.rs
@@ -41,7 +41,7 @@ pub fn read_tenant_configs(env_vars: Vec<(String, String)>) -> Vec<TenantConfig>
                 .find(|(v, _)| *v == format!("TENANT{}_ID", tc))
                 .iter()
                 .exactly_one()
-                .expect("need ID")
+                .expect("need TENANT_X_ID")
                 .1
                 .to_string(),
             rpc_addr: v
@@ -49,7 +49,7 @@ pub fn read_tenant_configs(env_vars: Vec<(String, String)>) -> Vec<TenantConfig>
                 .find(|(v, _)| *v == format!("TENANT{}_RPC_ADDR", tc))
                 .iter()
                 .exactly_one()
-                .expect("need RPC_ADDR")
+                .expect("need TENANT_X_RPC_ADDR")
                 .1
                 .to_string(),
             tx_status_ws_addr: v
@@ -57,7 +57,7 @@ pub fn read_tenant_configs(env_vars: Vec<(String, String)>) -> Vec<TenantConfig>
                 .find(|(v, _)| *v == format!("TENANT{}_TX_STATUS_WS_ADDR", tc))
                 .iter()
                 .exactly_one()
-                .expect("need TX_STATUS_WS_ADDR")
+                .expect("need TENANT_X_TX_STATUS_WS_ADDR")
                 .1
                 .to_string(),
         })

--- a/benchrunner-service/src/args.rs
+++ b/benchrunner-service/src/args.rs
@@ -6,6 +6,7 @@ pub struct TenantConfig {
     // technical identifier for the tenant, e.g. "solana-rpc"
     pub tenant_id: String,
     pub rpc_addr: String,
+    pub tx_status_ws_addr: String,
 }
 
 // recommend to use one payer keypair for all targets and fund that keypair with enough SOL

--- a/benchrunner-service/src/args.rs
+++ b/benchrunner-service/src/args.rs
@@ -7,7 +7,7 @@ pub struct TenantConfig {
     pub tenant_id: String,
     pub rpc_addr: String,
     // needs to point to a reliable websocket server that can be used to get tx status
-    pub tx_status_ws_addr: String,
+    pub tx_status_ws_addr: Option<String>,
 }
 
 // recommend to use one payer keypair for all targets and fund that keypair with enough SOL
@@ -56,10 +56,9 @@ pub fn read_tenant_configs(env_vars: Vec<(String, String)>) -> Vec<TenantConfig>
                 .iter()
                 .find(|(v, _)| *v == format!("TENANT{}_TX_STATUS_WS_ADDR", tc))
                 .iter()
-                .exactly_one()
+                .at_most_one()
                 .expect("need TENANT_X_TX_STATUS_WS_ADDR")
-                .1
-                .to_string(),
+                .map(|(_, v)| v.to_string())
         })
         .collect::<Vec<TenantConfig>>();
 

--- a/benchrunner-service/src/main.rs
+++ b/benchrunner-service/src/main.rs
@@ -43,13 +43,10 @@ async fn main() {
     let funded_payer = Arc::new(get_funded_payer_from_env());
 
     let tenant_configs = read_tenant_configs(std::env::vars().collect::<Vec<(String, String)>>());
-    // this should point to a reliable websocket RPC node
-    let tx_status_websocket_addr: String = std::env::var("TX_STATUS_WS_ADDR").expect("need TX_STATUS_WS_ADDR env var");
 
     info!("Use postgres config: {:?}", postgres_config.is_some());
     info!("Use prio fees: [{}]", prio_fees.iter().join(","));
     info!("Start running benchmarks every {:?}", bench_interval);
-    info!("Use websocket for tx status: {:?}", obfuscate_rpcurl(&tx_status_websocket_addr));
     info!(
         "Found tenants: {}",
         tenant_configs.iter().map(|tc| &tc.tenant_id).join(", ")
@@ -91,7 +88,6 @@ async fn main() {
         let tenant_id = tenant_config.tenant_id.clone();
         let postgres_session = postgres_session.clone();
         let tenant_config = tenant_config.clone();
-        let tx_status_websocket_addr = tx_status_websocket_addr.clone();
         let bench_configs = bench_configs.clone();
         let jh_runner = tokio::spawn(async move {
             let mut interval = tokio::time::interval(bench_interval);
@@ -108,7 +104,6 @@ async fn main() {
                     0 => Box::new(BenchRunnerConfirmationRateImpl {
                         benchrun_at,
                         tenant_config: tenant_config.clone(),
-                        tx_status_websocket_addr: tx_status_websocket_addr.clone(),
                         bench_config: bench_config.clone(),
                         funded_payer: funded_payer.clone(),
                         metric: OnceCell::new(),
@@ -243,7 +238,6 @@ impl BenchTrait for BenchRunnerConfirmationRateImpl {}
 struct BenchRunnerConfirmationRateImpl {
     pub benchrun_at: SystemTime,
     pub tenant_config: TenantConfig,
-    pub tx_status_websocket_addr: String,
     pub bench_config: BenchConfig,
     pub funded_payer: Arc<Keypair>,
     pub metric: OnceCell<confirmation_rate::Metric>,
@@ -255,7 +249,7 @@ impl BenchRunner for BenchRunnerConfirmationRateImpl {
         let metric = bench::service_adapter_new::benchnew_confirmation_rate_servicerunner(
             &self.bench_config,
             self.tenant_config.rpc_addr.clone(),
-            self.tx_status_websocket_addr.clone(),
+            self.tenant_config.tx_status_ws_addr.clone(),
             self.funded_payer.insecure_clone(),
         )
         .await;

--- a/benchrunner-service/src/postgres/metrics_dbstore.rs
+++ b/benchrunner-service/src/postgres/metrics_dbstore.rs
@@ -134,7 +134,7 @@ impl BenchMetricsPostgresSaver for BenchRunnerConfirmationRateImpl {
                 txs_confirmed,
                 txs_un_confirmed,
                 average_confirmation_time_ms,
-                average_slot_confirmation_time_ms,
+                average_slot_confirmation_time,
                 metric_json
              )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)

--- a/migrations/create_benchrunner.sql
+++ b/migrations/create_benchrunner.sql
@@ -48,6 +48,6 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA benchrunner GRANT SELECT ON TABLES TO ro_benc
 
 ALTER TABLE benchrunner.bench_metrics RENAME TO bench_metrics_bench1;
 
-ALTER TABLE benchrunner.bench_metrics_confirmation_rate ADD COLUMN bench_metrics_confirmation_rate real;
+ALTER TABLE benchrunner.bench_metrics_confirmation_rate ADD COLUMN average_slot_confirmation_time real;
 
 ALTER TABLE benchrunner.bench_metrics_confirmation_rate DROP COLUMN average_slot_confirmation_time_ms;

--- a/migrations/create_benchrunner.sql
+++ b/migrations/create_benchrunner.sql
@@ -47,3 +47,7 @@ GRANT SELECT ON ALL TABLES IN SCHEMA benchrunner TO ro_benchrunner;
 ALTER DEFAULT PRIVILEGES IN SCHEMA benchrunner GRANT SELECT ON TABLES TO ro_benchrunner;
 
 ALTER TABLE benchrunner.bench_metrics RENAME TO bench_metrics_bench1;
+
+ALTER TABLE benchrunner.bench_metrics_confirmation_rate ADD COLUMN bench_metrics_confirmation_rate real;
+
+ALTER TABLE benchrunner.bench_metrics_confirmation_rate DROP COLUMN average_slot_confirmation_time_ms;


### PR DESCRIPTION
replace get_signature_statuses polling by websocket _blockSubscribe_

the tx status progression gets tracked by a thread maintained in `tx_status_websocket_collector` which exposes the status as a shared concurrent map.
